### PR TITLE
Added reverse dns lookup for https server client certificate validation

### DIFF
--- a/source/vibe/http/server.d
+++ b/source/vibe/http/server.d
@@ -43,7 +43,7 @@ import std.functional;
 import std.string;
 import std.typecons;
 import std.uri;
-
+import std.socket;
 
 /**************************************************************************************************/
 /* Public functions                                                                               */
@@ -1191,8 +1191,14 @@ private void handleHTTPConnection(TCPConnection connection, HTTPServerListener l
 	// If this is a HTTPS server, initiate SSL
 	if (listen_info.sslContext) {
 		logTrace("accept ssl");
-		// TODO: reverse DNS lookup for peer_name of the incoming connection for SSL client certificate verification purposes
-		ssl_stream = createSSLStreamFL(http_stream, listen_info.sslContext, SSLStreamState.accepting, null, connection.remoteAddress);
+
+		Address peer;
+		try peer = parseAddress(connection.peerAddress);
+		catch (Exception e) peer = null;
+
+		auto peerHostName = peer ? peer.toHostNameString() : null;
+
+		ssl_stream = createSSLStreamFL(http_stream, listen_info.sslContext, SSLStreamState.accepting, peerHostName, connection.remoteAddress);
 		http_stream = ssl_stream;
 	}
 


### PR DESCRIPTION
Using the std.socket method for reverse dns lookups for now - I don't know enough about the various driver internals to know if there's a better asynchronous option available in some cases, but it at least meets the immediate needs.

reference: https://github.com/rejectedsoftware/vibe.d/issues/724

Dunno if we need to worry about the potential for a SocketFeatureException on the toHostNameString() call or not.
