### PR TITLE
Allocate arrays on the heap to avoid slower GC marking

### DIFF
--- a/source/vibe/core/drivers/libevent2_tcp.d
+++ b/source/vibe/core/drivers/libevent2_tcp.d
@@ -58,16 +58,15 @@ package final class Libevent2TCPConnection : TCPConnection {
 		bool m_timeout_triggered;
 		TCPContext* m_ctx;
 		string m_peerAddress;
-		ubyte[64] m_peekBuffer;
 		bool m_tcpNoDelay = false;
 		bool m_tcpKeepAlive = false;
 		Duration m_readTimeout;
-		char[64] m_peerAddressBuf;
 		NetworkAddress m_localAddress, m_remoteAddress;
 	}
 
 	this(TCPContext* ctx)
 	{
+		static char[64] peer_address_buf = void;
 		m_ctx = ctx;
 
 		assert(!amOwner());
@@ -78,9 +77,9 @@ package final class Libevent2TCPConnection : TCPConnection {
 		void* ptr;
 		if( ctx.remote_addr.family == AF_INET ) ptr = &ctx.remote_addr.sockAddrInet4.sin_addr;
 		else ptr = &ctx.remote_addr.sockAddrInet6.sin6_addr;
-		evutil_inet_ntop(ctx.remote_addr.family, ptr, m_peerAddressBuf.ptr, m_peerAddressBuf.length);
-		m_peerAddress = cast(string)m_peerAddressBuf[0 .. m_peerAddressBuf.indexOf('\0')];
-
+		evutil_inet_ntop(ctx.remote_addr.family, ptr, peer_address_buf.ptr, peer_address_buf.length);
+		m_peerAddress = cast(string)peer_address_buf[0 .. peer_address_buf.indexOf('\0')].idup;
+		
 		bufferevent_setwatermark(m_ctx.event, EV_WRITE, 4096, 65536);
 		bufferevent_setwatermark(m_ctx.event, EV_READ, 0, 65536);
 	}

--- a/source/vibe/db/redis/redis.d
+++ b/source/vibe/db/redis/redis.d
@@ -1352,7 +1352,6 @@ private struct RedisReplyContext {
 	bool frontIsNull = false;
 	long length = 1;
 	long index = 0;
-	ubyte[128] dataBuffer;
 }
 
 private final class RedisConnection {

--- a/source/vibe/stream/openssl.d
+++ b/source/vibe/stream/openssl.d
@@ -57,13 +57,14 @@ final class OpenSSLStream : SSLStream {
 		SSLStreamState m_state;
 		SSLState m_ssl;
 		BIO* m_bio;
-		ubyte[64] m_peekBuffer;
+		ubyte[] m_peekBuffer;
 		Exception[] m_exceptions;
 		SSLCertificateInformation m_peerCertificate;
 	}
 
 	this(Stream underlying, OpenSSLContext ctx, SSLStreamState state, string peer_name = null, NetworkAddress peer_address = NetworkAddress.init)
 	{
+		m_peekBuffer = new ubyte[64];
 		m_stream = underlying;
 		m_state = state;
 		m_sslCtx = ctx;

--- a/source/vibe/stream/openssl.d
+++ b/source/vibe/stream/openssl.d
@@ -190,7 +190,7 @@ final class OpenSSLStream : SSLStream {
 
 	const(ubyte)[] peek()
 	{
-		auto ret = SSL_peek(m_ssl, m_peekBuffer.ptr, m_peekBuffer.length);
+		auto ret = SSL_peek(m_ssl, cast(void*) m_peekBuffer.ptr, cast(int)m_peekBuffer.length);
 		checkExceptions();
 		return ret > 0 ? m_peekBuffer[0 .. ret] : null;
 	}

--- a/source/vibe/stream/wrapper.d
+++ b/source/vibe/stream/wrapper.d
@@ -164,13 +164,14 @@ struct StreamOutputRange {
 	private {
 		OutputStream m_stream;
 		size_t m_fill = 0;
-		ubyte[256] m_data = void;
+		ubyte[] m_data;
 	}
 
 	@disable this(this);
 
 	this(OutputStream stream)
 	{
+		m_data = new ubyte[256];
 		m_stream = stream;
 	}
 

--- a/source/vibe/stream/zlib.d
+++ b/source/vibe/stream/zlib.d
@@ -47,7 +47,7 @@ class ZlibOutputStream : OutputStream {
 	private {
 		OutputStream m_out;
 		z_stream m_zstream;
-		ubyte[1024] m_outbuffer;
+		ubyte[] m_outbuffer;
 		//ubyte[4096] m_inbuffer;
 		bool m_finalized = false;
 	}
@@ -59,6 +59,7 @@ class ZlibOutputStream : OutputStream {
 
 	this(OutputStream dst, HeaderFormat type, int level = Z_DEFAULT_COMPRESSION)
 	{
+		m_outbuffer = new ubyte[1024];
 		m_out = dst;
 		zlibEnforce(deflateInit2(&m_zstream, level, Z_DEFLATED, 15 + (type == HeaderFormat.gzip ? 16 : 0), 8, Z_DEFAULT_STRATEGY));
 	}
@@ -158,8 +159,8 @@ class ZlibInputStream : InputStream {
 	private {
 		InputStream m_in;
 		z_stream m_zstream;
-		FixedRingBuffer!(ubyte, 4096) m_outbuffer;
-		ubyte[1024] m_inbuffer;
+		FixedRingBuffer!(ubyte) m_outbuffer;
+		ubyte[] m_inbuffer;
 		bool m_finished = false;
 		ulong m_ninflated, n_read;
 	}
@@ -172,6 +173,9 @@ class ZlibInputStream : InputStream {
 
 	this(InputStream src, HeaderFormat type)
 	{
+		m_inbuffer = new ubyte[1024];
+		m_outbuffer.m_freeOnDestruct = true;
+		m_outbuffer.capacity = 4096;
 		m_in = src;
 		if (m_in.empty) {
 			m_finished = true;


### PR DESCRIPTION
It might sound contradictory but this is an actual issue until we get a precise GC

The objects affected are used fairly frequently. Having an array inlined in an object with pointers will not allow NO_SCAN to be marked on them, which forces the GC to scan their contents and make scanning very slow compared to not having them there. Yes, scanning takes orders of magnitude longer with those buffers there, especially for benchmarks that make a copy on every connection.

Moving those arrays in a separate allocation fixes this quite well.

Lastly, the peer address in libevent has the lifetime of the object. This is unsafe in the context of an API assumed to be garbage collected, as it produces a segmentation fault if the user needs to access it after the GC collects TCPConnection and gives back the memory to the OS.
