### PR TITLE
Fixes #1196 - Wait for redis listener to stop on Subscriber dtor

### DIFF
--- a/source/vibe/core/drivers/libevent2_tcp.d
+++ b/source/vibe/core/drivers/libevent2_tcp.d
@@ -68,6 +68,7 @@ package final class Libevent2TCPConnection : TCPConnection {
 
 	this(TCPContext* ctx)
 	{
+		import std.string : fromStringz;
 		m_ctx = ctx;
 
 		assert(!amOwner());
@@ -79,7 +80,7 @@ package final class Libevent2TCPConnection : TCPConnection {
 		if( ctx.remote_addr.family == AF_INET ) ptr = &ctx.remote_addr.sockAddrInet4.sin_addr;
 		else ptr = &ctx.remote_addr.sockAddrInet6.sin6_addr;
 		evutil_inet_ntop(ctx.remote_addr.family, ptr, m_peerAddressBuf.ptr, m_peerAddressBuf.length);
-		m_peerAddress = cast(string)m_peerAddressBuf[0 .. m_peerAddressBuf[].indexOf('\0')];
+		m_peerAddress = cast(string)m_peerAddressBuf.ptr.fromStringz;
 
 		bufferevent_setwatermark(m_ctx.event, EV_WRITE, 4096, 65536);
 		bufferevent_setwatermark(m_ctx.event, EV_READ, 0, 65536);

--- a/source/vibe/core/drivers/libevent2_tcp.d
+++ b/source/vibe/core/drivers/libevent2_tcp.d
@@ -68,7 +68,6 @@ package final class Libevent2TCPConnection : TCPConnection {
 
 	this(TCPContext* ctx)
 	{
-		import std.string : fromStringz;
 		m_ctx = ctx;
 
 		assert(!amOwner());
@@ -80,8 +79,8 @@ package final class Libevent2TCPConnection : TCPConnection {
 		if( ctx.remote_addr.family == AF_INET ) ptr = &ctx.remote_addr.sockAddrInet4.sin_addr;
 		else ptr = &ctx.remote_addr.sockAddrInet6.sin6_addr;
 		evutil_inet_ntop(ctx.remote_addr.family, ptr, m_peerAddressBuf.ptr, m_peerAddressBuf.length);
-		m_peerAddress = cast(string)m_peerAddressBuf.ptr.fromStringz;
-
+		static if (__VERSION__ >= 2066) m_peerAddress = cast(string)m_peerAddressBuf.ptr.fromStringz;
+		else m_peerAddress = cast(string)m_peerAddressBuf[0 .. m_peerAddressBuf[].indexOf('\0')];
 		bufferevent_setwatermark(m_ctx.event, EV_WRITE, 4096, 65536);
 		bufferevent_setwatermark(m_ctx.event, EV_READ, 0, 65536);
 	}

--- a/source/vibe/db/redis/redis.d
+++ b/source/vibe/db/redis/redis.d
@@ -651,6 +651,7 @@ final class RedisSubscriberImpl {
 			m_mutex.performLocked!({
 				m_stopWaiter = Task.getThis();
 			});
+			if (!m_listening) return; // verify again in case the mutex was locked by bstop
 			scope(exit) {
 				m_mutex.performLocked!({
 					m_stopWaiter = Task();


### PR DESCRIPTION
The task that owns RedisSubscriber will now block if it must go out of scope, waiting for ..something.. to stop the listener on its object.

This also fixes a compiler issue I had on 2.068 with `std.string.indexOf`

`fromStringz` takes a slice and uses `strlen`: https://github.com/D-Programming-Language/phobos/blob/b34ff324f0bfe539a12797f0b29359681c8c888b/std/string.d#L207
