### PR TITLE
Fix leak when a connection is closed by the server

### DIFF
--- a/source/vibe/core/drivers/libevent2_tcp.d
+++ b/source/vibe/core/drivers/libevent2_tcp.d
@@ -85,10 +85,12 @@ package final class Libevent2TCPConnection : TCPConnection {
 		bufferevent_setwatermark(m_ctx.event, EV_READ, 0, 65536);
 	}
 
-	/*~this()
+	~this()
 	{
+		if (m_ctx && m_ctx.state == ConnectionState.passiveClose)
+			TCPContextAlloc.free(m_ctx);
 		//assert(m_ctx is null, "Leaking TCPContext because it has not been cleaned up and we are not allowed to touch the GC in finalizers..");
-	}*/
+	}
 
 	@property void tcpNoDelay(bool enabled)
 	{

--- a/source/vibe/core/drivers/libevent2_tcp.d
+++ b/source/vibe/core/drivers/libevent2_tcp.d
@@ -376,6 +376,7 @@ package final class Libevent2TCPConnection : TCPConnection {
 		if (m_ctx && m_ctx.state == ConnectionState.passiveClose) {
 			if (m_ctx.event) bufferevent_free(m_ctx.event);
 			TCPContextAlloc.free(m_ctx);
+			m_ctx = null;
 		}
 	}
 

--- a/source/vibe/core/drivers/libevent2_tcp.d
+++ b/source/vibe/core/drivers/libevent2_tcp.d
@@ -87,8 +87,10 @@ package final class Libevent2TCPConnection : TCPConnection {
 
 	~this()
 	{
-		if (m_ctx && m_ctx.state == ConnectionState.passiveClose)
+		if (m_ctx && m_ctx.state == ConnectionState.passiveClose) {
+			if (m_ctx.event) bufferevent_free(m_ctx.event);
 			TCPContextAlloc.free(m_ctx);
+		}
 		//assert(m_ctx is null, "Leaking TCPContext because it has not been cleaned up and we are not allowed to touch the GC in finalizers..");
 	}
 
@@ -371,6 +373,10 @@ package final class Libevent2TCPConnection : TCPConnection {
 	void finalize()
 	{
 		flush();
+		if (m_ctx && m_ctx.state == ConnectionState.passiveClose) {
+			if (m_ctx.event) bufferevent_free(m_ctx.event);
+			TCPContextAlloc.free(m_ctx);
+		}
 	}
 
 	private void acquireReader() { assert(m_ctx.readOwner == Task(), "Acquiring reader of already owned connection."); m_ctx.readOwner = Task.getThis(); }


### PR DESCRIPTION
The higher level doesn't implement the means to track passively closed connections, other than the actual object's destructor.

For this reason, remotely closed connections will leave objects on the heap unless we finish cleaning up in `~this`.

fixes #1321 
