### PR TITLE
Fix #1421: Changed the LogLevel when an uncaught exception to a WebSocket is sent

### DIFF
--- a/source/vibe/http/websockets.d
+++ b/source/vibe/http/websockets.d
@@ -200,7 +200,7 @@ void handleWebSocket(scope WebSocketHandshakeDelegate on_handshake, scope HTTPSe
 	try {
 		on_handshake(socket);
 	} catch (Exception e) {
-		logDiagnostic("WebSocket handler failed: %s", e.msg);
+		logError("WebSocket handler failed: %s", e);
 	}
 	socket.close();
 }
@@ -253,7 +253,7 @@ HTTPServerRequestDelegateS handleWebSockets(WebSocketHandshakeDelegate on_handsh
 			/*scope*/ auto socket = new WebSocket(conn, req);
 			try on_handshake(socket);
 			catch (Exception e) {
-				logDiagnostic("WebSocket handler failed: %s", e.msg);
+				logError("WebSocket handler failed: %s", e);
 			} catch (Throwable th) {
 				// pretend to have sent a closing frame so that any further sends will fail
 				socket.m_sentCloseFrame = true;


### PR DESCRIPTION
When an exception is caught when handling a websocket connection, a logError should be sent instead with the traceback to aid in debugging the actual problem.
