### PR TITLE
Fix issue 1462 - fix file leak due to extra driver setup

### DIFF
--- a/core/vibe/core/concurrency.d
+++ b/core/vibe/core/concurrency.d
@@ -1279,7 +1279,11 @@ package class VibedScheduler : Scheduler {
 			if (LibasyncDriver.isControlThread)
 				return null;
 		}
-		setupDriver();
+		// due to useless creation of a new Condition during std.concurrency module
+		// destructor, setupDriver call is necessary in versions prior to 2.072
+		static if (__VERSION__ < 2072) {
+			setupDriver();
+		}
 		return new TaskCondition(m);
 	}
 }


### PR DESCRIPTION
Fixes https://github.com/rejectedsoftware/vibe.d/issues/1462 but requires Phobos fix https://github.com/D-Programming-Language/phobos/pull/4191.

If this is pulled before Phobos has the fix, an assertion will fail:

```
core.exception.AssertError@vibe.d/source/vibe/core/concurrency.d(1227): Assertion failure
----------------
??:? _d_assert [0x6340cf]
??:? void vibe.core.concurrency.__assert(int) [0x60113b]
vibe.d/source/vibe/core/concurrency.d:1227 nothrow vibe.core.sync.TaskCondition vibe.core.concurrency.VibedScheduler.newCondition(core.sync.mutex.Mutex) [0x601388]
??:? @trusted std.concurrency.MessageBox std.concurrency.MessageBox.__ctor() [0x647793]
??:? @trusted std.concurrency.Tid std.concurrency.thisTid().__dgliteral1() [0x646f66]
??:? @property @safe std.concurrency.Tid std.concurrency.thisTid() [0x646f16]
??:? void std.concurrency.unregisterMe() [0x683620]
??:? void std.concurrency.ThreadInfo.cleanup() [0x647028]
??:? void std.concurrency._staticDtor265() [0x646aa8]
??:? void std.concurrency.__moddtor() [0x646ab8]
```

So maybe this needs to be versioned before pulling.
