### PR TITLE
Add CodeCov badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Visit the website at <http://vibed.org/> for more information.
 [![DUB Package](https://img.shields.io/dub/v/vibe-d.svg)](https://code.dlang.org/packages/vibe-d)
 [![Posix Build Status](https://travis-ci.org/rejectedsoftware/vibe.d.svg?branch=master)](https://travis-ci.org/rejectedsoftware/vibe.d)
 [![Windows Build Status](https://ci.appveyor.com/api/projects/status/cp2kxg70h54pga9d/branch/master?svg=true)](https://ci.appveyor.com/project/s-ludwig/vibe-d/branch/master)
-
+[![Code coverage](https://img.shields.io/codecov/c/github/rejectedsoftware/vibe.d.svg?maxAge=86400)](https://codecov.io/gh/rejectedsoftware/vibe.d)
 
 Support
 -------


### PR DESCRIPTION
Didn't think about this in the initial PR, sorry.
At least it's a good opportunity to test whether CodeCov now sends status updates ;-)

Preview: 

![image](https://user-images.githubusercontent.com/4370550/27773480-ea80a75c-5f7a-11e7-8302-9e08ed0260d2.png)

Of course, once [Travis build 3613](https://travis-ci.org/rejectedsoftware/vibe.d/builds/249414450) (the build for #1808 on master) has passed, the coverage badge will update itself.