### PR TITLE
Added forward proxy support  and included an example

### DIFF
--- a/examples/http_forward_proxy/dub.json
+++ b/examples/http_forward_proxy/dub.json
@@ -1,0 +1,8 @@
+﻿{
+	"name": "http-forward-proxy-example",
+	"description": "Sets up a simple forward proxy.",
+	"dependencies": {
+		"vibe-d:http": {"path": "../../"}
+	},
+	"versions": ["VibeDefaultMain"]
+}

--- a/examples/http_forward_proxy/source/app.d
+++ b/examples/http_forward_proxy/source/app.d
@@ -1,0 +1,13 @@
+import vibe.appmain;
+import vibe.http.proxy;
+import vibe.http.server;
+
+
+shared static this()
+{
+	auto settings = new HTTPServerSettings;
+	settings.port = 8080;
+	settings.bindAddresses = ["::1", "127.0.0.1"];
+
+	listenHTTPForwardProxy(settings);
+}

--- a/http/vibe/http/proxy.d
+++ b/http/vibe/http/proxy.d
@@ -75,7 +75,7 @@ HTTPServerRequestDelegateS proxyRequest(HTTPProxySettings settings)
 	void handleRequest(scope HTTPServerRequest req, scope HTTPServerResponse res)
 	@safe {
 		auto url = settings.destination;
-		
+
 		if (settings.reverseProxyMode) {
 			url.localURI = req.requestURL;
 		}
@@ -224,6 +224,7 @@ HTTPServerRequestDelegateS reverseProxyRequest(HTTPProxySettings settings)
 {
 	return proxyRequest(settings);
 }
+
 /// ditto
 HTTPServerRequestDelegateS reverseProxyRequest(string destination_host, ushort destination_port)
 {

--- a/http/vibe/http/proxy.d
+++ b/http/vibe/http/proxy.d
@@ -56,9 +56,9 @@ void listenHTTPReverseProxy(HTTPServerSettings settings, string destination_host
 	listenHTTPReverseProxy(settings, proxy_settings);
 }
 
-/** 
-	Transparently forwards all requests to the proxy to the requestURL of the request. 
-*/ 
+/**
+	Transparently forwards all requests to the proxy to the requestURL of the request.
+*/
 void listenHTTPForwardProxy(HTTPServerSettings settings) {
 	auto proxy_settings = new HTTPProxySettings(ProxyMode.forward);
 	proxy_settings.handleConnectRequests = true;


### PR DESCRIPTION
Overview of changes:
- Generalized 'HTTPReverseProxySettings' into 'HTTPProxySettings' and added a bool for setting reverse proxy mode.
- Moved the 'handleRequest' code out of 'reverseProxyRequest' and into a general 'proxyRequest' function.
- Created a 'forwardProxyRequest' function and updated the 'reverseProxyRequest' function to then call into 'proxyRequest' with the properly set 'HTTPProxySettings' where necessary.
- Created new 'listenHTTPForwardProxy' methods to compliment the existing 'listenHTTPReverseProxy' functions.

Testing:
All unit tests pass. I tested both the existing 'http_reverse_proxy' example and the new 'http_forward_proxy' example to ensure they were both working. NOTE*: the 'http_forward_proxy' example will only work with HTTP sites, not HTTPS. Trying to access an HTTPS site will show error 'proxy is refusing connections'. Setting up the HTTP listener to use SSL will solve this, although that will drop support for regular HTTP sites.

Notes:
Ideally the example would be better off working with both HTTP and HTTPS, so it could truly be used like a general purpose forward proxy. This would require having a listener that can handle both normal and TLS encrypted TCP connections. I don't believe Vibe.d currently supports this (let me know if I'm wrong), but I have some ideas on how to add support for this.

If there are any desired changes or updates to this PR, feel free to let me know. I won't take any offense.