### PR TITLE
setCommandLineArgs

### DIFF
--- a/core/vibe/core/args.d
+++ b/core/vibe/core/args.d
@@ -168,6 +168,7 @@ bool finalizeCommandLineOptions(string[]* args_out = null)
 /**
 	This functions allows the usage of a custom command line argument parser
 	with vibe.d.
+
 	$(OL
 		$(LI build executable with version(VibeDisableCommandLineParsing))
 		$(LI parse main function arguments with a custom command line parser)
@@ -178,7 +179,8 @@ bool finalizeCommandLineOptions(string[]* args_out = null)
 	Params:
 		args = The arguments that should be handled by vibe.d
 */
-void setCommandLineArgs(string[] args) {
+void setCommandLineArgs(string[] args)
+{
 	g_args = args;
 }
 

--- a/core/vibe/core/args.d
+++ b/core/vibe/core/args.d
@@ -165,6 +165,29 @@ bool finalizeCommandLineOptions(string[]* args_out = null)
 	return true;
 }
 
+/**
+	This functions allows the usage of a custom command line argument parser
+	with vibe.d.
+	$(OL
+		$(LI build executable with version(VibeDisableCommandLineParsing))
+		$(LI parse main function arguments with a custom command line parser)
+		$(LI pass vibe.d arguments to `setCommandLineArgs`)
+		$(LI use vibe.d command line parsing utilities)
+	)
+
+	Params:
+		args = The arguments that should be handled by vibe.d
+*/
+void setCommandLineArgs(string[] args) {
+	g_args = args;
+}
+
+///
+unittest {
+	import std.format : format;
+	string[] args = ["--foo", "10"];
+	setCommandLineArgs(args);
+}
 
 private struct OptionInfo {
 	string[] names;


### PR DESCRIPTION
This allows to handle command line args before the vibe.d cmd hanlder kicks in.
This is needed if a user for example wants to handle --help|-h by himself or wants to use a custom parser.