### PR TITLE
travis: Workaround for pip install Travis issue

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,6 +51,7 @@ matrix:
       env: VIBED_DRIVER=libasync BUILD_EXAMPLE=0 RUN_TEST=0
 
 before_install:
+  - pyenv global system 3.5
   - pip3 install meson>=0.40
 
 install:


### PR DESCRIPTION
@s-ludwig:
> Travis builds start to fail, because of something that changed with their system packaging: https://travis-ci.org/vibe-d/vibe.d/jobs/274722352
>
> Do you know of a more portable way to access pip/pip3?

Annoying... They should just make a base image based on a current Ubuntu release (like, the last LTS, not a prehistoric one) test it until they like it and then throw it out without modifying much (new browsers and security/integration fixes etc. are exceptions).
They warned about the image changing, but this particular change is missing from the changelog :P https://docs.travis-ci.com/user/build-environment-updates/2017-09-06/

Anyway, I was playing around with this a little, but Travis seems to be on low capacity at time, so I am not sure if this patch works (we'll see).