### PR TITLE
Make handleHTTPConnection public

### DIFF
--- a/http/vibe/http/dist.d
+++ b/http/vibe/http/dist.d
@@ -23,7 +23,7 @@ import std.process;
 
 	This function is usable as direct replacement of listenHTTP
 */
-void listenHTTPDist(HTTPServerSettings settings, HTTPServerRequestDelegate handler, string balancer_address, ushort balancer_port = 11000)
+HTTPListener listenHTTPDist(HTTPServerSettings settings, HTTPServerRequestDelegate handler, string balancer_address, ushort balancer_port = 11000)
 @safe {
 	Json regmsg = Json.emptyObject;
 	regmsg["host_name"] = settings.hostName;
@@ -36,7 +36,7 @@ void listenHTTPDist(HTTPServerSettings settings, HTTPServerRequestDelegate handl
 	local_settings.bindAddresses = ["127.0.0.1"];
 	local_settings.port = 0;
 	local_settings.disableDistHost = true;
-	listenHTTP(local_settings, handler);
+	auto ret = listenHTTP(local_settings, handler);
 
 	requestHTTP(URL("http://"~balancer_address~":"~to!string(balancer_port)~"/register"), (scope req){
 			logInfo("Listening for VibeDist connections on port %d", req.localAddress.port);
@@ -47,4 +47,6 @@ void listenHTTPDist(HTTPServerSettings settings, HTTPServerRequestDelegate handl
 		}, (scope res){
 			enforce(res.statusCode == HTTPStatus.ok, "Failed to register with load balancer.");
 		});
+
+	return ret;
 }

--- a/http/vibe/http/server.d
+++ b/http/vibe/http/server.d
@@ -1,7 +1,7 @@
 /**
 	A HTTP 1.1/1.0 server implementation.
 
-	Copyright: © 2012-2013 RejectedSoftware e.K.
+	Copyright: © 2012-2017 RejectedSoftware e.K.
 	License: Subject to the terms of the MIT license, as written in the included LICENSE.txt file.
 	Authors: Sönke Ludwig, Jan Krüger, Ilya Shipunov
 */
@@ -1806,6 +1806,11 @@ final class HTTPServerContext {
 		if (settings.accessLogFile.length)
 			vhost.loggers ~= new HTTPFileLogger(settings, settings.accessLogFormat, settings.accessLogFile);
 
+		if (!m_virtualHosts.length) m_tlsContext = settings.tlsContext;
+
+		enforce((m_tlsContext !is null) == (settings.tlsContext !is null),
+			"Cannot mix HTTP and HTTPS virtual hosts within the same listener.");
+
 		if (m_tlsContext) addSNIHost(settings);
 
 		m_virtualHosts ~= vhost;
@@ -1834,11 +1839,6 @@ final class HTTPServerContext {
 
 	private void addSNIHost(HTTPServerSettings settings)
 	{
-		if (!m_virtualHosts.length) m_tlsContext = settings.tlsContext;
-
-		enforce((m_tlsContext !is null) == (settings.tlsContext !is null),
-			"Cannot mix HTTP and HTTPS virtual hosts within the same listener.");
-
 		if (settings.tlsContext !is m_tlsContext && m_tlsContext.kind != TLSContextKind.serverSNI) {
 			logDebug("Create SNI TLS context for %s, port %s", bindAddress, bindPort);
 			m_tlsContext = createTLSContext(TLSContextKind.serverSNI);


### PR DESCRIPTION
This allows accepting incoming HTTP connections on a custom transport, such as a pre-established TCP connection, or a USDS socket.