### PR TITLE
Add methods to support client request digest authentication

### DIFF
--- a/examples/.travis.run
+++ b/examples/.travis.run
@@ -7,6 +7,7 @@ echoserver
 form_interface
 http_info
 http_request
+http_request_digest
 http_reverse_proxy
 http_server
 https_server

--- a/examples/http_request_digest/dub.json
+++ b/examples/http_request_digest/dub.json
@@ -1,0 +1,9 @@
+﻿{
+	"name": "http-request-digest-example",
+	"description": "Performs a custom HTTP request with digest authentication.",
+	"authors": [ "Sönke Ludwig" ],
+	"dependencies": {
+		"vibe-d:http": {"path": "../../"}
+	},
+	"versions": ["VibeCustomMain"]
+}

--- a/examples/http_request_digest/source/app.d
+++ b/examples/http_request_digest/source/app.d
@@ -1,0 +1,47 @@
+import vibe.core.log;
+import vibe.http.auth.digest_auth;
+import vibe.http.client;
+
+import std.algorithm;
+import std.format;
+import std.random;
+
+enum username = "bond";
+enum password = "007";
+
+void main()
+{
+	auto url = URL("http://httpbin.org/digest-auth/auth/" ~ username ~ "/" ~ password ~ "/MD5");
+	requestHTTP(url,
+		(scope req) {
+		},
+		(scope res) {
+			logInfo("Response: %d", res.statusCode);
+			foreach (k, v; res.headers)
+				logInfo("Header: %s: %s", k, v);
+
+			auto pc = "Set-Cookie" in res.headers;
+
+			if (res.statusCode == 401 && res.headers["WWW-Authenticate"]) {
+				auto auth = res.headers["WWW-Authenticate"];
+				if (auth.startsWith("Digest ")) {
+					requestHTTP(url,
+						(scope req) {
+							auto resp = createDigestAuthHeader(
+								HTTPMethod.GET, url, username, password, DigestAuthParams(auth),
+								format("%08x", uniform!int), 1);
+								logInfo("Digest request: %s", resp);
+							req.headers["Authorization"] = resp;
+							if (pc !is null) req.headers["Cookie"] = *pc;
+						},
+						(scope res) {
+							logInfo("Response: %d", res.statusCode);
+							foreach (k, v; res.headers)
+								logInfo("Header: %s: %s", k, v);
+						}
+					);
+				}
+			}
+		}
+	);
+}


### PR DESCRIPTION
Added the method to generate digest authentication request header from the response digest parameters.

Also added the example to test it.
It works for the start but I would like to solve also the problem with `cnonce` and `nc` parameters.

If I understand it correctly, cnonce should be the same if the server uses the previous nonce and nc just incremented in following client requests.
For that it is needed to store the values somewhere on the client.
I think that maybe if we add Variant context storage to the HTTPClient and make it accessible from the HTTPClientRequest and HTTPClientResponse it can be used for this as HTTPClient is reused from the pool. Also it should be cleared when the connection is closed.

Is this the correct way of thinking to provide facilities to implement digest authentication for the client calls properly?