### PR TITLE
Support the noRoute attribute in the REST interface generator.

### DIFF
--- a/web/vibe/web/common.d
+++ b/web/vibe/web/common.d
@@ -405,6 +405,33 @@ unittest
 
 
 /**
+	Methods marked with this attribute will not be treated as web endpoints.
+
+	This attribute enables the definition of public methods that do not take
+	part in the interface genration process.
+*/
+@property NoRouteAttribute noRoute()
+{
+	import vibe.web.common : onlyAsUda;
+	if (!__ctfe)
+		assert(false, onlyAsUda!__FUNCTION__);
+	return NoRouteAttribute.init;
+}
+
+///
+unittest {
+	interface IAPI {
+		// Accessible as "GET /info"
+		string getInfo();
+
+		// Not accessible over HTTP
+		@noRoute
+		int getFoo();
+	}
+}
+
+
+/**
  	Respresents a Rest error response
 */
 class RestException : HTTPStatusException {
@@ -451,6 +478,9 @@ package struct PathAttribute
 	string data;
 	alias data this;
 }
+
+/// private
+package struct NoRouteAttribute {}
 
 /// Private struct describing the origin of a parameter (Query, Header, Body).
 package struct WebParamAttribute {

--- a/web/vibe/web/internal/rest/common.d
+++ b/web/vibe/web/internal/rest/common.d
@@ -12,6 +12,7 @@ import vibe.web.rest;
 
 import std.algorithm : endsWith, startsWith;
 import std.meta : anySatisfy, Filter;
+import std.traits : hasUDA;
 
 
 /**
@@ -403,7 +404,7 @@ import std.meta : anySatisfy, Filter;
 				enum name = memberNames[idx];
 				// WORKAROUND #1045 / @@BUG14375@@
 				static if (name.length != 0)
-					alias Impl = TypeTuple!(MemberFunctionsTuple!(I, name), Impl!(idx+1));
+					alias Impl = TypeTuple!(Filter!(IsRouteMethod, MemberFunctionsTuple!(I, name)), Impl!(idx+1));
 				else alias Impl = Impl!(idx+1);
 			} else alias Impl = TypeTuple!();
 		}
@@ -425,6 +426,8 @@ import std.meta : anySatisfy, Filter;
 		return ret;
 	}
 }
+
+private enum IsRouteMethod(alias M) = !hasUDA!(M, NoRouteAttribute);
 
 struct Route {
 	string functionName; // D name of the function

--- a/web/vibe/web/web.d
+++ b/web/vibe/web/web.d
@@ -574,33 +574,6 @@ string trWeb(string text, string plural_text, int count, string context = null)
 
 
 /**
-	Methods marked with this attribute will not be treated as web endpoints.
-
-	This attribute enables the definition of public methods that do not take
-	part in the interface genration process.
-*/
-@property NoRouteAttribute noRoute()
-{
-	import vibe.web.common : onlyAsUda;
-	if (!__ctfe)
-		assert(false, onlyAsUda!__FUNCTION__);
-	return NoRouteAttribute.init;
-}
-
-///
-unittest {
-	interface IAPI {
-		// Accessible as "GET /info"
-		string getInfo();
-
-		// Not accessible over HTTP
-		@noRoute
-		int getFoo();
-	}
-}
-
-
-/**
 	Attribute to customize how errors/exceptions are displayed.
 
 	The first template parameter takes a function that maps an exception and an
@@ -761,8 +734,6 @@ struct SessionVar(T, string name) {
 
 	alias value this;
 }
-
-private struct NoRouteAttribute {}
 
 private struct ErrorDisplayAttribute(alias DISPLAY_METHOD) {
 	import std.traits : ParameterTypeTuple, ParameterIdentifierTuple;


### PR DESCRIPTION
It used to be supported by the web interface generator. This commit moves it to vibe.web.common.