### PR TITLE
Implement HTTPServerRequest.requestPath as a replacement for .path.

### DIFF
--- a/core/vibe/core/path.d
+++ b/core/vibe/core/path.d
@@ -151,7 +151,7 @@ struct Path {
 	@property bool absolute() const { return m_absolute; }
 
 	/// Forward compatibility property for vibe-code
-	@property immutable(PathEntry)[] bySegment() { return nodes; }
+	@property immutable(PathEntry)[] bySegment() const { return nodes; }
 
 	/// Resolves all '.' and '..' path entries as far as possible.
 	void normalize()


### PR DESCRIPTION
See #1628 and #1635 - this provides a suitable base for implementing a more correct router matching functionality.