### PR TITLE
ignore druntime arguments

### DIFF
--- a/core/vibe/core/args.d
+++ b/core/vibe/core/args.d
@@ -16,7 +16,7 @@ module vibe.core.args;
 import vibe.core.log;
 import vibe.data.json;
 
-import std.algorithm : any, map, sort;
+import std.algorithm : any, filter, map, sort, startsWith;
 import std.array : array, join, replicate, split;
 import std.exception;
 import std.file;
@@ -222,7 +222,7 @@ private void init()
 	import vibe.utils.string : stripUTF8Bom;
 
 	version (VibeDisableCommandLineParsing) {}
-	else g_args = Runtime.args;
+	else g_args = Runtime.args.filter!(arg => !arg.startsWith("--DRT-")).array;
 
 	if (!g_args.length) g_args = ["dummy"];
 

--- a/tests/args/test.sh
+++ b/tests/args/test.sh
@@ -11,6 +11,7 @@ fi
 
 ( $VIBE | grep -q '^argtest=$' ) || die "Fail (no argument)"
 ( $VIBE -- --argtest=aoeu | grep -q '^argtest=aoeu$' ) || die "Fail (with argument)"
+( $VIBE -- --argtest=aoeu --DRT-gcopt=profile:1 | grep -q '^argtest=aoeu$' ) || die "Fail (with argument)"
 ( ( ! $VIBE -- --inexisting 2>&1 ) | grep -qF 'Unrecognized command line option' ) || die "Fail (unknown argument)"
 
 echo 'OK'


### PR DESCRIPTION
As vibe.d is using low-level Runtime.args from which the `--DRT-` arguments are not filtered.