### PR TITLE
Replace static assert in with unittest

### DIFF
--- a/utils/vibe/utils/dictionarylist.d
+++ b/utils/vibe/utils/dictionarylist.d
@@ -350,7 +350,10 @@ struct DictionaryList(VALUE, bool case_sensitive = true, size_t NUM_STATIC_FIELD
 	}
 }
 
-static assert(DictionaryList!(string, true, 2).safeValueCopy);
+@safe unittest
+{
+	assert(DictionaryList!(string, true, 2).safeValueCopy);
+}
 
 @safe unittest {
 	DictionaryList!(int, true) a;


### PR DESCRIPTION
I had some issues with this static assert generating undefined references when building with -inline (in 'profile' builds) with dmd.

I created an issue on the dmd bug tracker (See https://issues.dlang.org/show_bug.cgi?id=17895) but this fixes my issue without having to wait for them to fix it and I don't see why this assert couldn't be a unit test instead.