### PR TITLE
Fix Meson build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,10 +9,10 @@ services:
 addons:
   apt:
     packages:
-    - libevent-dev
-    - libssl-dev
-    - pkg-config
-    - zlib1g-dev
+      - pkg-config
+      - zlib1g-dev
+      - libevent-dev
+      - libssl-dev
 
 d:
   # order: latest DMD, oldest DMD, LDC/GDC, remaining DMD versions
@@ -52,11 +52,11 @@ matrix:
 
 before_install:
   - pyenv global system 3.5
-  - pip3 install meson>=0.40
+  - pip3 install 'meson>=0.42,!=0.43'
 
 install:
   - mkdir .ntmp
-  - curl -L https://github.com/ninja-build/ninja/releases/download/v1.7.2/ninja-linux.zip -o .ntmp/ninja-linux.zip
+  - curl -L https://github.com/ninja-build/ninja/releases/download/v1.8.2/ninja-linux.zip -o .ntmp/ninja-linux.zip
   - unzip .ntmp/ninja-linux.zip -d .ntmp
 
 before_script:

--- a/travis-ci.sh
+++ b/travis-ci.sh
@@ -52,35 +52,34 @@ if [ ${RUN_TEST=1} -eq 1 ]; then
 fi
 
 # test building with Meson
-# NOTE: temporarily disabled due to error "Native dependency 'diet' not found"
-#if [[ ${VIBED_DRIVER=libevent} = libevent ]]; then
-#    mkdir build && cd build
-#    meson ..
-#
-#    allow_meson_test="yes"
-#    if [[ ${DC=dmd} = ldc2 ]]; then
-#        # we can not run tests when compiling with LDC+Meson on Travis at the moment,
-#        # due to an LDC bug: https://github.com/ldc-developers/ldc/issues/2280
-#        # as soon as the bug is fixed, we can run tests again for the fixed LDC versions.
-#        allow_meson_test="no"
-#    fi
-#    if [[ ${DC=dmd} = dmd ]]; then
-#        dc_version=$("$DC" --version | perl -pe '($_)=/([0-9]+([.][0-9]+)+)/')
-#        if [[ ${dc_version} = "2.072.2" ]]; then
-#            # The stream test fails with DMD 2.072.2 due to a missing symbol. This is a DMD bug,
-#            # so we skip tests here.
-#            # This check can be removed when support for that compiler version is dropped.
-#            allow_meson_test="no"
-#        fi
-#    fi
-#
-#    # we limit the number of Ninja jobs to 4, so Travis doesn't kill us
-#    ninja -j4
-#
-#    if [[ ${allow_meson_test} = "yes" ]]; then
-#        ninja test -v
-#    fi
-#    DESTDIR=/tmp/vibe-install ninja install
-#
-#    cd ..
-#fi
+if [[ ${VIBED_DRIVER=libevent} = libevent ]]; then
+    mkdir build && cd build
+    meson ..
+
+    allow_meson_test="yes"
+    if [[ ${DC=dmd} = ldc2 ]]; then
+        # we can not run tests when compiling with LDC+Meson on Travis at the moment,
+        # due to an LDC bug: https://github.com/ldc-developers/ldc/issues/2280
+        # as soon as the bug is fixed, we can run tests again for the fixed LDC versions.
+        allow_meson_test="no"
+    fi
+    if [[ ${DC=dmd} = dmd ]]; then
+        dc_version=$("$DC" --version | perl -pe '($_)=/([0-9]+([.][0-9]+)+)/')
+        if [[ ${dc_version} = "2.072.2" ]]; then
+            # The stream test fails with DMD 2.072.2 due to a missing symbol. This is a DMD bug,
+            # so we skip tests here.
+            # This check can be removed when support for that compiler version is dropped.
+            allow_meson_test="no"
+        fi
+    fi
+
+    # we limit the number of Ninja jobs to 4, so Travis doesn't kill us
+    ninja -j4
+
+    if [[ ${allow_meson_test} = "yes" ]]; then
+        ninja test -v
+    fi
+    DESTDIR=/tmp/vibe-install ninja install
+
+    cd ..
+fi


### PR DESCRIPTION
Meson broke its wrap support in the 0.43 release, this PR excludes the faulty version from being used and also updates the Ninja version used for building.

This error is fixed in newer Meson versions, see https://github.com/mesonbuild/meson/commit/36d85db5d41b1f3a8e3f13a1680d1758353b23f7 for details.

Cheers,
    Matthias
