### PR TITLE
Use more universal inout modifier instead of const

### DIFF
--- a/core/vibe/core/task.d
+++ b/core/vibe/core/task.d
@@ -66,10 +66,8 @@ struct Task {
 		}
 
 		// FIXME: this is not thread safe!
-		@property ref ThreadInfo tidInfo() { return m_fiber ? fiber.tidInfo : s_tidInfo; }
-		@property ref const(ThreadInfo) tidInfo() const { return m_fiber ? fiber.tidInfo : s_tidInfo; }
-		@property Tid tid() { return tidInfo.ident; }
-		@property const(Tid) tid() const { return tidInfo.ident; }
+		@property ref inout(ThreadInfo) tidInfo() inout { return m_fiber ? fiber.tidInfo : s_tidInfo; }
+		@property inout(Tid) tid() inout { return tidInfo.ident; }
 	}
 
 	/// Reserved for internal use!


### PR DESCRIPTION
Removes the extra methods just due to const. This is inout's wheelhouse.

RE: http://forum.rejectedsoftware.com/groups/rejectedsoftware.vibed/post/46769