### PR TITLE
Set SO_REUSEPORT for the libevent driver on BSD/macOS, too.

### DIFF
--- a/core/vibe/core/drivers/libevent2.d
+++ b/core/vibe/core/drivers/libevent2.d
@@ -386,7 +386,7 @@ final class Libevent2Driver : EventDriver {
 		int tmp_reuse = 1;
 		socketEnforce(() @trusted { return setsockopt(listenfd, SOL_SOCKET, SO_REUSEADDR, &tmp_reuse, tmp_reuse.sizeof); } () == 0,
 			"Error enabling socket address reuse on listening socket");
-		version (linux) {
+		static if (is(typeof(SO_REUSEPORT))) {
 			if (options & TCPListenOptions.reusePort) {
 				if (() @trusted { return setsockopt(listenfd, SOL_SOCKET, SO_REUSEPORT, &tmp_reuse, tmp_reuse.sizeof); } ()) {
 					if (errno != EINVAL && errno != ENOPROTOOPT) {

--- a/core/vibe/core/drivers/utils.d
+++ b/core/vibe/core/drivers/utils.d
@@ -43,11 +43,10 @@ version (Windows) {
 	alias SystemSocketException = WSAErrorException;
 } else alias SystemSocketException = ErrnoException;
 
-version (linux) {
-	import core.sys.posix.sys.socket;
-	static if (!is(typeof(SO_REUSEPORT))) {
-		enum { SO_REUSEPORT = 15 }
-	}
+import core.sys.posix.sys.socket;
+static if (!is(typeof(SO_REUSEPORT))) {
+	version (linux) enum SO_REUSEPORT = 15;
+	else enum SO_REUSEPORT = 0x200;
 }
 
 T socketEnforce(T)(T value, lazy string msg = null, string file = __FILE__, size_t line = __LINE__)


### PR DESCRIPTION
See #1749.