### PR TITLE
Added spec defined websocket close enum

### DIFF
--- a/http/vibe/http/websockets.d
+++ b/http/vibe/http/websockets.d
@@ -384,6 +384,7 @@ HTTPServerRequestDelegateS handleWebSockets(void function(scope WebSocket) @syst
  */
 enum WebSocketCloseReason : short
 {
+	none = 0,
 	normalClosure = 1000,
 	goingAway = 1001,
 	protocolError = 1002,
@@ -678,20 +679,16 @@ final class WebSocket {
 			code = Numeric code indicating a termination reason.
 			reason = Message describing why the connection was terminated.
 	*/
-	void close(short code = 0, scope const(char)[] reason = "")
+	void close(short code = WebSocketCloseReason.normalClosure, scope const(char)[] reason = "")
 	{
-		//assume the default is normal, intentional closure
-		if(code == 0)
-			code = WebSocketCloseReason.normalClosure;
-
-		if(reason is null || reason.length == 0)
+		if(reason.length == 0)
 			reason = (cast(WebSocketCloseReason)code).toString;
 
 		//control frame payloads are limited to 125 bytes
 		version(assert)
 			assert(reason.length <= 123);
 		else
-			reason = reason[0 .. 123];
+			reason = reason[0 .. min($, 123)];
 
 		if (connected) {
 			send((scope msg) {

--- a/http/vibe/http/websockets.d
+++ b/http/vibe/http/websockets.d
@@ -359,6 +359,102 @@ HTTPServerRequestDelegateS handleWebSockets(void function(scope WebSocket) @syst
 	});
 }
 
+/**
+ * Provides the reason that a websocket connection has closed.
+ *
+ * Further documentation for the WebSocket and it's codes can be found from:
+ * https://developer.mozilla.org/en-US/docs/Web/API/CloseEvent
+ *
+ * ---
+ *
+ * void echoSocket(scope WebSocket sock)
+ * {
+ *   import std.datetime : seconds;
+ *
+ *   while(sock.waitForData(3.seconds))
+ *   {
+ *     string msg = sock.receiveText;
+ *     logInfo("Got a message: %s", msg);
+ *     sock.send(msg);
+ *   }
+ *
+ *   if(sock.connected)
+ *     sock.close(WebSocketCloseReason.policyViolation, "timeout");
+ * }
+ */
+enum WebSocketCloseReason : short
+{
+	normalClosure = 1000,
+	goingAway = 1001,
+	protocolError = 1002,
+	unsupportedData = 1003,
+	noStatusReceived = 1005,
+	abnormalClosure = 1006,
+	invalidFramePayloadData = 1007,
+	policyViolation = 1008,
+	messageTooBig = 1009,
+	internalError = 1011,
+	serviceRestart = 1012,
+	tryAgainLater = 1013,
+	badGateway = 1014,
+	tlsHandshake = 1015
+}
+
+string toString(WebSocketCloseReason reason) @nogc @safe
+{
+	switch(reason / 1000)
+	{
+		case 0:
+			return "Reserved and Unused";
+		case 1:
+			switch(reason)
+			{
+				case 1000:
+					return "Normal Closure";
+				case 1001:
+					return "Going Away";
+				case 1002:
+					return "Protocol Error";
+				case 1003:
+					return "Unsupported Data";
+				case 1004:
+					return "RESERVED";
+				case 1005:
+					return "No Status Recvd";
+				case 1006:
+					return "Abnormal Closure";
+				case 1007:
+					return "Invalid Frame Payload Data";
+				case 1008:
+					return "Policy Violation";
+				case 1009:
+					return "Message Too Big";
+				case 1010:
+					return "Missing Extension";
+				case 1011:
+					return "Internal Error";
+				case 1012:
+					return "Service Restart";
+				case 1013:
+					return "Try Again Later";
+				case 1014:
+					return "Bad Gateway";
+				case 1015:
+					return "TLS Handshake";
+				default:
+					return "RESERVED";
+			}
+		case 2:
+			return "Reserved for extensions";
+		case 3:
+			return "Available for frameworks and libraries";
+		case 4:
+			return "Available for applications";
+		default:
+			return "UNDEFINED - Nasal Demons";
+	}
+}
+
 
 /**
  * Represents a single _WebSocket connection.
@@ -569,6 +665,9 @@ final class WebSocket {
 	{
 		//control frame payloads are limited to 125 bytes
 		assert(reason.length <= 123);
+
+		if(reason.length == 0)
+			reason = (cast(WebSocketCloseReason)code).toString;
 
 		if (connected) {
 			send((scope msg) {

--- a/http/vibe/http/websockets.d
+++ b/http/vibe/http/websockets.d
@@ -471,6 +471,15 @@ unittest
 	assert((cast(WebSocketCloseReason)4000).closeReasonString == "Available for applications");
 	assert((cast(WebSocketCloseReason)5000).closeReasonString == "UNDEFINED - Nasal Demons");
 	assert((cast(WebSocketCloseReason)  -1).closeReasonString == "UNDEFINED - Nasal Demons");
+
+	//check the other spec cases
+	for(short i = 1000; i < 1017; i++)
+	{
+		if(i == 1004 || i > 1015)
+			assert((cast(WebSocketCloseReason)i).closeReasonString != "RESERVED");
+		else
+			assert((cast(WebSocketCloseReason)i).closeReasonString == "RESERVED");
+	}
 }
 
 

--- a/http/vibe/http/websockets.d
+++ b/http/vibe/http/websockets.d
@@ -476,9 +476,17 @@ unittest
 	for(short i = 1000; i < 1017; i++)
 	{
 		if(i == 1004 || i > 1015)
-			assert((cast(WebSocketCloseReason)i).closeReasonString != "RESERVED");
+		{
+			assert(
+				(cast(WebSocketCloseReason)i).closeReasonString == "RESERVED",
+				"(incorrect) code %d = %s".format(i, closeReasonString(cast(WebSocketCloseReason)i))
+			);
+		}
 		else
-			assert((cast(WebSocketCloseReason)i).closeReasonString == "RESERVED");
+			assert(
+				(cast(WebSocketCloseReason)i).closeReasonString != "RESERVED",
+				"(incorrect) code %d = %s".format(i, closeReasonString(cast(WebSocketCloseReason)i))
+			);
 	}
 }
 

--- a/http/vibe/http/websockets.d
+++ b/http/vibe/http/websockets.d
@@ -401,7 +401,7 @@ enum WebSocketCloseReason : short
 	tlsHandshake = 1015
 }
 
-string toString(WebSocketCloseReason reason) @nogc @safe
+string closeReasonString(WebSocketCloseReason reason) @nogc @safe
 {
 	import std.math : floor;
 
@@ -461,16 +461,16 @@ string toString(WebSocketCloseReason reason) @nogc @safe
 
 unittest
 {
-	assert((cast(WebSocketCloseReason)   0).toString == "Reserved and Unused");
-	assert((cast(WebSocketCloseReason)   1).toString == "Reserved and Unused");
-	assert(WebSocketCloseReason.normalClosure.toString == "Normal Closure");
-	assert(WebSocketCloseReason.abnormalClosure.toString == "Abnormal Closure");
-	assert((cast(WebSocketCloseReason)1020).toString == "RESERVED");
-	assert((cast(WebSocketCloseReason)2000).toString == "Reserved for extensions");
-	assert((cast(WebSocketCloseReason)3000).toString == "Available for frameworks and libraries");
-	assert((cast(WebSocketCloseReason)4000).toString == "Available for applications");
-	assert((cast(WebSocketCloseReason)5000).toString == "UNDEFINED - Nasal Demons");
-	assert((cast(WebSocketCloseReason)  -1).toString == "UNDEFINED - Nasal Demons");
+	assert((cast(WebSocketCloseReason)   0).closeReasonString == "Reserved and Unused");
+	assert((cast(WebSocketCloseReason)   1).closeReasonString == "Reserved and Unused");
+	assert(WebSocketCloseReason.normalClosure.closeReasonString == "Normal Closure");
+	assert(WebSocketCloseReason.abnormalClosure.closeReasonString == "Abnormal Closure");
+	assert((cast(WebSocketCloseReason)1020).closeReasonString == "RESERVED");
+	assert((cast(WebSocketCloseReason)2000).closeReasonString == "Reserved for extensions");
+	assert((cast(WebSocketCloseReason)3000).closeReasonString == "Available for frameworks and libraries");
+	assert((cast(WebSocketCloseReason)4000).closeReasonString == "Available for applications");
+	assert((cast(WebSocketCloseReason)5000).closeReasonString == "UNDEFINED - Nasal Demons");
+	assert((cast(WebSocketCloseReason)  -1).closeReasonString == "UNDEFINED - Nasal Demons");
 }
 
 
@@ -682,7 +682,7 @@ final class WebSocket {
 	void close(short code = WebSocketCloseReason.normalClosure, scope const(char)[] reason = "")
 	{
 		if(reason.length == 0)
-			reason = (cast(WebSocketCloseReason)code).toString;
+			reason = (cast(WebSocketCloseReason)code).closeReasonString;
 
 		//control frame payloads are limited to 125 bytes
 		version(assert)

--- a/http/vibe/http/websockets.d
+++ b/http/vibe/http/websockets.d
@@ -402,7 +402,10 @@ enum WebSocketCloseReason : short
 
 string toString(WebSocketCloseReason reason) @nogc @safe
 {
-	switch(reason / 1000)
+	import std.math : floor;
+
+	//round down to the nearest thousand to get category
+	switch(cast(short)(cast(float)reason / 1000f).floor)
 	{
 		case 0:
 			return "Reserved and Unused";
@@ -453,6 +456,20 @@ string toString(WebSocketCloseReason reason) @nogc @safe
 		default:
 			return "UNDEFINED - Nasal Demons";
 	}
+}
+
+unittest
+{
+	assert((cast(WebSocketCloseReason)   0).toString == "Reserved and Unused");
+	assert((cast(WebSocketCloseReason)   1).toString == "Reserved and Unused");
+	assert(WebSocketCloseReason.normalClosure.toString == "Normal Closure");
+	assert(WebSocketCloseReason.abnormalClosure.toString == "Abnormal Closure");
+	assert((cast(WebSocketCloseReason)1020).toString == "RESERVED");
+	assert((cast(WebSocketCloseReason)2000).toString == "Reserved for extensions");
+	assert((cast(WebSocketCloseReason)3000).toString == "Available for frameworks and libraries");
+	assert((cast(WebSocketCloseReason)4000).toString == "Available for applications");
+	assert((cast(WebSocketCloseReason)5000).toString == "UNDEFINED - Nasal Demons");
+	assert((cast(WebSocketCloseReason)  -1).toString == "UNDEFINED - Nasal Demons");
 }
 
 

--- a/http/vibe/http/websockets.d
+++ b/http/vibe/http/websockets.d
@@ -698,7 +698,7 @@ final class WebSocket {
 	*/
 	void close(short code = WebSocketCloseReason.normalClosure, scope const(char)[] reason = "")
 	{
-		if(reason.length == 0)
+		if(reason !is null && reason.length == 0)
 			reason = (cast(WebSocketCloseReason)code).closeReasonString;
 
 		//control frame payloads are limited to 125 bytes


### PR DESCRIPTION
This enum and function provide access to the defined websocket close
codes and will also generate the reason string based off of the code if
one isn't already defined.  This saves library users from having to look
up documentation.