### PR TITLE
Portable way to get the processor count on Linux

### DIFF
--- a/core/vibe/core/core.d
+++ b/core/vibe/core/core.d
@@ -692,7 +692,7 @@ public @property uint logicalProcessorCount()
 {
 	version (linux) {
 		import core.sys.posix.unistd;
-        return sysconf(_SC_NPROCESSORS_ONLN);
+		return cast(uint) sysconf(_SC_NPROCESSORS_ONLN);
 	} else version (OSX) {
 		int count;
 		size_t count_len = count.sizeof;

--- a/core/vibe/core/core.d
+++ b/core/vibe/core/core.d
@@ -691,8 +691,8 @@ public void setupWorkerThreads(uint num = logicalProcessorCount())
 public @property uint logicalProcessorCount()
 {
 	version (linux) {
-		import core.sys.linux.sys.sysinfo;
-		return get_nprocs();
+		import core.sys.posix.unistd;
+        return sysconf(_SC_NPROCESSORS_ONLN);
 	} else version (OSX) {
 		int count;
 		size_t count_len = count.sizeof;


### PR DESCRIPTION
The initial code was not very portable across various C run-time libs, for example uClibc doesn't provide the `get_nprocs` function