### PR TITLE
Fix issue 2004: DictionaryList.get doesn't work with class/interface

### DIFF
--- a/utils/vibe/utils/dictionarylist.d
+++ b/utils/vibe/utils/dictionarylist.d
@@ -402,7 +402,7 @@ unittest {
 }
 
 // Issue 2004
-@safe unittest {
+unittest {
 	import std.variant : Variant;
 	DictionaryList!Variant l;
 	class C {

--- a/utils/vibe/utils/dictionarylist.d
+++ b/utils/vibe/utils/dictionarylist.d
@@ -400,3 +400,15 @@ unittest {
 	assert(text(l) == `["foo": 42, "bar": 43]`, text(l));
 	assert(l.toString() == `["foo": 42, "bar": 43]`, l.toString());
 }
+
+// Issue 2004
+@safe unittest {
+	import std.variant : Variant;
+	DictionaryList!Variant l;
+	class C {
+		int x = 123;
+	}
+	l["foo"] = new C;
+	auto c = l.get!C("foo");
+	assert(c.x == 123);
+}

--- a/utils/vibe/utils/dictionarylist.d
+++ b/utils/vibe/utils/dictionarylist.d
@@ -195,7 +195,7 @@ struct DictionaryList(VALUE, bool case_sensitive = true, size_t NUM_STATIC_FIELD
 	/// ditto
 	inout(T) get(T)(string key) // Work around DMD bug
 	inout if (typedGet!T) {
-		return get!T(key, T.init);
+		return get!T(key, inout(T).init);
 	}
 
 	/** Returns all values matching the given key.


### PR DESCRIPTION
Turns out that the fix for issue #2004 is trivial: the default argument just needs to be specified with the `inout` qualifier.