### PR TITLE
Explicitly request "mongodb" service for AppVeyor builds.

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -56,6 +56,9 @@ environment:
 
 skip_tags: false
 
+services:
+  - mongodb
+
 install:
   - ps: function SetUpDCompiler
         {


### PR DESCRIPTION
Due to some change, the MongoDB test fails/hangs currently.