### PR TITLE
Fix a few deprecation warnings

### DIFF
--- a/examples/bench-http-request/source/app.d
+++ b/examples/bench-http-request/source/app.d
@@ -3,7 +3,12 @@ import vibe.core.core;
 import vibe.http.client;
 
 import core.atomic;
-import std.datetime;
+
+static if (__VERSION__ >= 2076)
+	import std.datetime.stopwatch;
+else
+	import std.datetime;
+
 import std.functional;
 import std.stdio;
 
@@ -77,7 +82,11 @@ void benchmark()
 
 	long keep_alives = 0;
 	while (true) {
-		auto tm = sw.peek().msecs;
+		static if (__VERSION__ >= 2076)
+			auto tm = sw.peek().total!"msecs";
+		else
+			auto tm = sw.peek().msecs;
+
 		if (nreq >= nreqc && tm >= next_ts) {
 			writefln("%s iterations: %s req/s, %s err/s (%s active conn, %s disconnects/s)", nreq, (nreq*1_000)/tm, (nerr*1_000)/tm, nconn, (ndisconns*1_000)/tm);
 			nreqc.atomicOp!"+="(1000);

--- a/examples/bench-mongodb/source/app.d
+++ b/examples/bench-mongodb/source/app.d
@@ -1,6 +1,9 @@
 import vibe.core.log;
 import vibe.db.mongo.mongo;
-import std.datetime;
+static if (__VERSION__ >= 2076)
+	import std.datetime.stopwatch;
+else
+	import std.datetime;
 import std.string : format;
 
 
@@ -10,7 +13,10 @@ Duration runTimed(scope void delegate() del)
 	sw.start();
 	del();
 	sw.stop();
-	return cast(Duration)sw.peek;
+	static if (__VERSION__ >= 2076)
+		return sw.peek;
+	else
+		return cast(Duration) sw.peek;
 }
 
 void main()

--- a/examples/bench-urlrouter/source/app.d
+++ b/examples/bench-urlrouter/source/app.d
@@ -2,7 +2,10 @@ import vibe.core.log;
 import vibe.http.router;
 import vibe.http.server;
 import vibe.inet.url;
-import std.datetime;
+static if (__VERSION__ >= 2076)
+	import std.datetime.stopwatch;
+else
+	import std.datetime;
 import std.string : format;
 
 
@@ -18,7 +21,10 @@ Duration runTimed(scope void delegate() del)
 	sw.start();
 	del();
 	sw.stop();
-	return cast(Duration)sw.peek;
+	static if (__VERSION__ >= 2076)
+		return sw.peek;
+	else
+		return cast(Duration) sw.peek;
 }
 
 void main()

--- a/examples/file_operations/source/app.d
+++ b/examples/file_operations/source/app.d
@@ -2,10 +2,22 @@ import vibe.core.core;
 import vibe.core.file;
 import std.stdio;
 
+static if (__VERSION__ >= 2076)
+	import std.datetime.stopwatch;
+else
+	import std.datetime;
+
+auto peekMSecs(T)(T sw)
+{
+static if (__VERSION__ >= 2076)
+	return sw.peek.total!"msecs";
+else
+	return sw.peek.msecs;
+}
+
 shared static this()
 {
 	FileStream fs = openFile("./hello.txt", FileMode.createTrunc);
-	import std.datetime;
 	StopWatch sw;
 	sw.start();
 	bool finished;
@@ -19,10 +31,10 @@ shared static this()
 			fs.seek(off);
 		}
 		writeln("Task 1: Starting write operations to hello.txt");
-		while(sw.peek().msecs < 150) {
+		while(sw.peekMSecs < 150) {
 			fs.write("Some string is being written here ..");
 		}
-		writeln("Task 1: Final offset: ", fs.tell(), "B, file size: ", fs.size(), "B", ", total time: ", sw.peek().msecs, " ms");
+		writeln("Task 1: Final offset: ", fs.tell(), "B, file size: ", fs.size(), "B", ", total time: ", sw.peekMSecs, " ms");
 		fs.close();
 		finished = true;
 	});
@@ -30,7 +42,7 @@ shared static this()
 	runTask({
 		while(!finished)
 		{
-			writeln("Task 2: Task 1 has written ", fs.size(), "B so far in ", sw.peek().msecs, " ms");
+			writeln("Task 2: Task 1 has written ", fs.size(), "B so far in ", sw.peekMSecs, " ms");
 			sleep(10.msecs);
 		}
 		removeFile("./hello.txt");


### PR DESCRIPTION
There's still a lot more going on. It might be worthwhile to compile all tests and examples with `-de`?