### PR TITLE
null string deserialization typecheck fix

### DIFF
--- a/data/vibe/data/json.d
+++ b/data/vibe/data/json.d
@@ -1077,7 +1077,7 @@ struct Json {
 	private void checkType(TYPES...)(string op = null)
 	const {
 		bool matched = false;
-		foreach (T; TYPES) if (m_type == typeId!T) matched = true;
+		foreach (T; TYPES) if (m_type == typeId!T || (is(T == string) && m_type == Type.null_)) matched = true;
 		if (matched) return;
 
 		string name;
@@ -2500,4 +2500,17 @@ private auto trustedRange(R)(R range)
 	assert(b.foos.length == 1);
 	assert(b.foos[0].i == 2);
 	assert(b.foos[0].foos.length == 0);
+}
+
+@safe unittest { // null string deserialization
+	static struct Foo { @optional string bar; }
+	auto f = deserializeJson!Foo(`{"bar":null}`);
+	assert(f.bar is null);
+
+	auto j = parseJsonString(`{"bar":null}`);
+	assert(j["bar"].get!string is null);
+
+	auto pv = "bar" in j;
+	auto v = deserializeJson!string(*pv);
+	assert(v is null);
 }


### PR DESCRIPTION
Just a simple exception to pass Json.Type.null_ as a string too as string can be set to null in the json data.

Without this I get this error when not used with the Nullable in the REST API:
```
Exception while handling request POST /api/v1/events/iot/temp: vibe.http.common.HTTPStatusException@/home/tomas/.dub/packages/vibe-d-0.8.2/vibe-d/web/vibe/web/rest.d(1333): Got JSON of type null_, expected string.
----------------
/usr/include/dmd/phobos/std/exception.d:556 pure @safe bool std.exception.enforce!(bool).enforce(bool, lazy object.Throwable) [0xd1bc30]
/home/tomas/.dub/packages/vibe-d-0.8.2/vibe-d/http/vibe/http/common.d:161 @safe bool vibe.http.common.enforceHTTP!(bool).enforceHTTP(bool, vibe.http.status.HTTPStatus, lazy immutable(char)[], immutable(char)[], int) [0xd33cd7]
/home/tomas/.dub/packages/vibe-d-0.8.2/vibe-d/http/vibe/http/common.d:169 @safe bool vibe.http.common.enforceBadRequest!(bool).enforceBadRequest(bool, lazy immutable(char)[], immutable(char)[], int) [0xd7d734]
/home/tomas/.dub/packages/vibe-d-0.8.2/vibe-d/web/vibe/web/rest.d:1333 @safe void vibe.web.rest.jsonMethodHandler
```

but I'm not sure if this is ok to add or even enough. What with structs/classes or arrays in the same scenario?
