### PR TITLE
Fix: forward RedisValue methods hidden in redis types by overloads

### DIFF
--- a/redis/vibe/db/redis/types.d
+++ b/redis/vibe/db/redis/types.d
@@ -602,6 +602,7 @@ struct RedisZSet(T = string) {
 
 	long insert(ARGS...)(ARGS args) { return m_db.zadd(m_key, args); }
 	long remove(ARGS...)(ARGS members) { return m_db.zrem(m_key, members); }
+	void remove()() { value.remove(); }
 	long length() { return m_db.zcard(m_key); }
 
 	long count(string INT = "[]")(double min, double max)

--- a/redis/vibe/db/redis/types.d
+++ b/redis/vibe/db/redis/types.d
@@ -374,6 +374,7 @@ struct RedisHash(T = string) {
 	bool remove() { return value.remove(); }
 	size_t remove(scope string[] fields...) { return cast(size_t)m_db.hdel(m_key, fields); }
 	bool exists(string field) { return m_db.hexists(m_key, field); }
+	bool exists() { return value.exists; }
 
 	void opIndexAssign(T value, string field) { m_db.hset(m_key, field, value.toRedis()); }
 	T opIndex(string field) { return m_db.hget!string(m_key, field).fromRedis!T(); }

--- a/redis/vibe/db/redis/types.d
+++ b/redis/vibe/db/redis/types.d
@@ -371,7 +371,7 @@ struct RedisHash(T = string) {
 
 	this(RedisDatabase db, string key) { value = RedisValue(db, key); }
 
-	bool remove()() { return value.remove(); }
+	bool remove() { return value.remove(); }
 	size_t remove(scope string[] fields...) { return cast(size_t)m_db.hdel(m_key, fields); }
 	bool exists(string field) { return m_db.hexists(m_key, field); }
 
@@ -550,7 +550,7 @@ struct RedisSet(T = string) {
 
 	long insert(ARGS...)(ARGS args) { return m_db.sadd(m_key, args); }
 	long remove(T value) { return m_db.srem(m_key, value.toRedis()); }
-	bool remove()() { return value.remove(); }
+	bool remove() { return value.remove(); }
 	string pop() { return m_db.spop!string(m_key); }
 	long length() { return m_db.scard(m_key); }
 
@@ -602,7 +602,7 @@ struct RedisZSet(T = string) {
 
 	long insert(ARGS...)(ARGS args) { return m_db.zadd(m_key, args); }
 	long remove(ARGS...)(ARGS members) { return m_db.zrem(m_key, members); }
-	bool remove()() { return value.remove(); }
+	bool remove() { return value.remove(); }
 	long length() { return m_db.zcard(m_key); }
 
 	long count(string INT = "[]")(double min, double max)

--- a/redis/vibe/db/redis/types.d
+++ b/redis/vibe/db/redis/types.d
@@ -371,7 +371,7 @@ struct RedisHash(T = string) {
 
 	this(RedisDatabase db, string key) { value = RedisValue(db, key); }
 
-	void remove()() { value.remove(); }
+	bool remove()() { return value.remove(); }
 	size_t remove(scope string[] fields...) { return cast(size_t)m_db.hdel(m_key, fields); }
 	bool exists(string field) { return m_db.hexists(m_key, field); }
 
@@ -550,7 +550,7 @@ struct RedisSet(T = string) {
 
 	long insert(ARGS...)(ARGS args) { return m_db.sadd(m_key, args); }
 	long remove(T value) { return m_db.srem(m_key, value.toRedis()); }
-	void remove()() { value.remove(); }
+	bool remove()() { return value.remove(); }
 	string pop() { return m_db.spop!string(m_key); }
 	long length() { return m_db.scard(m_key); }
 
@@ -602,7 +602,7 @@ struct RedisZSet(T = string) {
 
 	long insert(ARGS...)(ARGS args) { return m_db.zadd(m_key, args); }
 	long remove(ARGS...)(ARGS members) { return m_db.zrem(m_key, members); }
-	void remove()() { value.remove(); }
+	bool remove()() { return value.remove(); }
 	long length() { return m_db.zcard(m_key); }
 
 	long count(string INT = "[]")(double min, double max)

--- a/redis/vibe/db/redis/types.d
+++ b/redis/vibe/db/redis/types.d
@@ -371,6 +371,7 @@ struct RedisHash(T = string) {
 
 	this(RedisDatabase db, string key) { value = RedisValue(db, key); }
 
+	void remove()() { value.remove(); }
 	size_t remove(scope string[] fields...) { return cast(size_t)m_db.hdel(m_key, fields); }
 	bool exists(string field) { return m_db.hexists(m_key, field); }
 


### PR DESCRIPTION
All supported redis values now work as per the test below:
```d
auto db = connectRedis("127.0.0.1").getDatabase(0);
db.getAsList("test_list").remove();
db.getAsSet("test_set").remove();
db.getAsZSet("test_zset").remove();
db.getAsHash("test_hash").remove();
db.getAsString("test_string").remove();
```
