### PR TITLE
small optimization for jsonEscape

### DIFF
--- a/data/vibe/data/json.d
+++ b/data/vibe/data/json.d
@@ -2164,15 +2164,24 @@ string convertJsonToASCII(string json)
 /// private
 private void jsonEscape(bool escape_unicode = false, R)(ref R dst, string s)
 {
-	char lastch;
+	size_t startPos = 0;
+	
+	void putInterval(size_t curPos)
+	{
+		if (curPos > startPos)
+			dst.put(s[startPos..curPos]);
+		startPos = curPos + 1;
+	}
+
 	for (size_t pos = 0; pos < s.length; pos++) {
 		immutable(char) ch = s[pos];
 
 		switch (ch) {
 			default:
 				static if (escape_unicode) {
-					if (ch > 0x20 && ch < 0x80) dst.put(ch);
-					else {
+					if (ch <= 0x20 || ch >= 0x80)
+					{
+						putInterval(pos);
 						import std.utf : decode;
 						int len;
 						dchar codepoint = decode(s, pos);
@@ -2192,29 +2201,36 @@ private void jsonEscape(bool escape_unicode = false, R)(ref R dst, string s)
 
 							dst.formattedWrite("\\u%04X\\u%04X", first, last);
 						}
-
 						pos -= 1;
-
 					}
-				} else {
-					if (ch < 0x20) dst.formattedWrite("\\u%04X", ch);
-					else dst.put(ch);
+				} 
+				else 
+				{
+					if (ch < 0x20)
+					{
+						putInterval(pos);
+						dst.formattedWrite("\\u%04X", ch);
+					}
 				}
 				break;
-			case '\\': dst.put("\\\\"); break;
-			case '\r': dst.put("\\r"); break;
-			case '\n': dst.put("\\n"); break;
-			case '\t': dst.put("\\t"); break;
-			case '\"': dst.put("\\\""); break;
+			case '\\': putInterval(pos); dst.put("\\\\"); break;
+			case '\r': putInterval(pos); dst.put("\\r"); break;
+			case '\n': putInterval(pos); dst.put("\\n"); break;
+			case '\t': putInterval(pos); dst.put("\\t"); break;
+			case '\"': putInterval(pos); dst.put("\\\""); break;
 			case '/':
 				// this avoids the sequence "</" in the output, which is prone
 				// to cross site scripting attacks when inserted into web pages
-				if (lastch == '<') dst.put("\\/");
-				else dst.put(ch);
+				if (pos > 0 && s[pos-1] == '<')
+				{
+					putInterval(pos);
+					dst.put("\\/");
+				}
 				break;
 		}
-		lastch = ch;
 	}
+	// if the whole string was unescaped
+	putInterval(s.length);
 }
 
 /// private

--- a/data/vibe/data/json.d
+++ b/data/vibe/data/json.d
@@ -2201,6 +2201,7 @@ private void jsonEscape(bool escape_unicode = false, R)(ref R dst, string s)
 
 							dst.formattedWrite("\\u%04X\\u%04X", first, last);
 						}
+						startPos = pos;
 						pos -= 1;
 					}
 				} 

--- a/data/vibe/data/json.d
+++ b/data/vibe/data/json.d
@@ -2165,7 +2165,7 @@ string convertJsonToASCII(string json)
 private void jsonEscape(bool escape_unicode = false, R)(ref R dst, string s)
 {
 	size_t startPos = 0;
-	
+
 	void putInterval(size_t curPos)
 	{
 		if (curPos > startPos)
@@ -2204,8 +2204,8 @@ private void jsonEscape(bool escape_unicode = false, R)(ref R dst, string s)
 						startPos = pos;
 						pos -= 1;
 					}
-				} 
-				else 
+				}
+				else
 				{
 					if (ch < 0x20)
 					{
@@ -2230,7 +2230,7 @@ private void jsonEscape(bool escape_unicode = false, R)(ref R dst, string s)
 				break;
 		}
 	}
-	// if the whole string was unescaped
+	// last interval
 	putInterval(s.length);
 }
 


### PR DESCRIPTION
According to Callgrind this function is the heavies one in the process of json serialization of string-heavy objects. This pull request is aimed to improve it's performance a little by reducing the frequency of dst.put calls and getting rid of lastch reassignment on every iteration. This reduces the time (exclusive) spent in this function by ~2% and reduces the number of "put" invocations considerably, giving ~10% improvement of total (inclusive) time on my test case.   


Also, are you sure about that 
```
pos -= 1;
```
in escape_unicode version of this function? I'm getting an infinite loop feeling.