### PR TITLE
Only build master on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,11 @@ addons:
       - libevent-dev
       - libssl-dev
 
+branches:
+  only:
+  - master
+  - 0.7.x
+
 d:
   # order: latest DMD, oldest DMD, LDC/GDC, remaining DMD versions
   # this way the overall test time gets cut down (GDC/LDC are a lot

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -66,7 +66,11 @@ environment:
     arch: x64
     config: vibe-core
 
-skip_tags: false
+branches:
+  only:
+    - master
+    - 0.7.x
+skip_tags: true
 
 services:
   - mongodb


### PR DESCRIPTION
Should reduce this redundancy from four to two CI runs:

![image](https://user-images.githubusercontent.com/4370550/34908630-23864fbe-f893-11e7-999b-f9537459dbfa.png)