### PR TITLE
unbreak and deprecate REST return types with unsafe serialization

### DIFF
--- a/web/vibe/web/rest.d
+++ b/web/vibe/web/rest.d
@@ -1407,8 +1407,12 @@ private HTTPServerRequestDelegate jsonMethodHandler(alias Func, size_t ridx, T)(
 
 				ret = () @trusted { return evaluateOutputModifiers!CFunc(ret, req, res); } ();
 				returnHeaders();
-				debug res.writePrettyJsonBody(ret);
-				else res.writeJsonBody(ret);
+				static if (!__traits(compiles, () @safe { res.writeJsonBody(ret); }))
+					pragma(msg, "Non-@safe serialization of REST return types deprecated - ensure that "~RT.stringof~" is safely serializable.");
+				() @trusted {
+					debug res.writePrettyJsonBody(ret);
+					else res.writeJsonBody(ret);
+				}();
 			}
 		} catch (HTTPStatusException e) {
 			if (res.headerWritten)


### PR DESCRIPTION
- e.g. b/c of a custom fromRepresentation method

Unfortunately not easily possible to give a more exact error message.