### PR TITLE
http.server: handle an empty Json body

### DIFF
--- a/http/vibe/http/server.d
+++ b/http/vibe/http/server.d
@@ -985,6 +985,7 @@ final class HTTPServerRequest : HTTPRequest {
 				if (icmp2(contentType, "application/json") == 0 || icmp2(contentType, "application/vnd.api+json") == 0 ) {
 					auto bodyStr = bodyReader.readAllUTF8();
 					if (!bodyStr.empty) _json = parseJson(bodyStr);
+					else _json = Json.undefined;
 				} else {
 					_json = Json.undefined;
 				}

--- a/tests/vibe.http.server.empty-json/dub.sdl
+++ b/tests/vibe.http.server.empty-json/dub.sdl
@@ -1,0 +1,3 @@
+name "tests"
+description "Receive an empty JSON body"
+dependency "vibe-d:http" path="../../"

--- a/tests/vibe.http.server.empty-json/source/app.d
+++ b/tests/vibe.http.server.empty-json/source/app.d
@@ -1,0 +1,34 @@
+import vibe.core.core : runTask, runEventLoop, exitEventLoop;
+import vibe.data.json : serializeToJsonString;
+import vibe.http.client : requestHTTP;
+import vibe.http.server;
+import vibe.stream.operations : readAllUTF8;
+
+import std.conv : to;
+
+void main()
+{
+	auto s1 = new HTTPServerSettings;
+	s1.options &= ~HTTPServerOption.errorStackTraces;
+	s1.bindAddresses = ["127.0.0.1"];
+	s1.port = 11721;
+	listenHTTP(s1, &handler);
+
+	runTask({
+		scope (exit) exitEventLoop();
+		try {
+			auto req = requestHTTP("http://127.0.0.1:" ~ s1.port.to!string);
+			assert(req.bodyReader.readAllUTF8 == "JSON: null - World!\r\n");
+		} catch (Exception e) {
+			assert(false, e.msg);
+		}
+	});
+	runEventLoop();
+}
+
+void handler(scope HTTPServerRequest req, scope HTTPServerResponse res)
+{
+	req.contentType = "application/json; charset=UTF-8";
+	res.bodyWriter.write("JSON: " ~ req.json.serializeToJsonString);
+	res.bodyWriter.write(" - World!\r\n");
+}


### PR DESCRIPTION
If `req.json` is called on an empty Json body, it throws an error message which
is rather hard to understand for the casual observer:

```
core.exception.AssertError@/usr/include/dlang/dmd/std/typecons.d(2583): Called `get' on null Nullable!Json.
----------------
??:? _d_assert_msg [0xb539aeea]
??:? inout pure nothrow ref @property @nogc @safe inout(vibe.data.json.Json) std.typecons.Nullable!(vibe.data.json.Json).Nullable.get() [0xb5224d99]
??:? ref @property @safe vibe.data.json.Json vibe.http.server.HTTPServerRequest.json() [0xb521431d]
??:? void app.handler(scope vibe.http.server.HTTPServerRequest, vibe.http.server.HTTPServerResponse) [0xb51e4b4e]
??:? @trusted void vibe.http.server.listenHTTP!(vibe.http.server.HTTPServerSettings).listenHTTP(vibe.http.server.HTTPServerSettings, void function(scope vibe.http.server.HTTPServerRequest, vibe.http.server.HTTPServerResponse)*).__lambda3!(vibe.http.server.HTTPServerRequest, vibe.http.server.HTTPServerResponse).__lambda3(scope vibe.http.server.HTTPServerRequest, scope vibe.http.server.HTTPServerResponse) [0xb51eea3b]
??:? @safe bool vibe.http.server.handleRequest(vibe.internal.interfaceproxy.InterfaceProxy!(vibe.core.stream.Stream).InterfaceProxy, vibe.core.net.TCPConnection, vibe.http.server.HTTPServerContext, ref vibe.http.server.HTTPServerSettings, ref bool, scope stdx.allocator.IAllocator) [0xb5286a8d]
??:? @trusted void vibe.http.server.handleHTTPConnection(vibe.core.net.TCPConnection, vibe.http.server.HTTPServerContext).__lambda4() [0xb5284f46]
??:? @safe void vibe.http.server.handleHTTPConnection(vibe.core.net.TCPConnection, vibe.http.server.HTTPServerContext) [0xb5284c57]
??:? nothrow @safe void vibe.http.server.listenHTTPPlain(vibe.http.server.HTTPServerSettings, void delegate(vibe.http.server.HTTPServerRequest, vibe.http.server.HTTPServerResponse) @safe).doListen(vibe.http.server.HTTPServerContext, bool, bool).__lambda4(vibe.core.net.TCPConnection) [0xb52185a5]
??:? void vibe.core.task.TaskFuncInfo.set!(void delegate(vibe.core.net.TCPConnection) @safe, vibe.core.net.TCPConnection).set(ref void delegate(vibe.core.net.TCPConnection) @safe, ref vibe.core.net.TCPConnection).callDelegate(ref vibe.core.task.TaskFuncInfo) [0xb5351580]
??:? void vibe.core.task.TaskFuncInfo.call() [0xb533184d]
??:? nothrow void vibe.core.task.TaskFiber.run() [0xb5330e65]
??:? void core.thread.Fiber.run() [0xb53e7edb]
??:? fiber_entryPoint [0xb53e7daa]
??:? [0xffffffff]
```