### PR TITLE
Bump DUB version used on AppVeyor to 1.7.1

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -115,7 +115,7 @@ install:
             }
         }
   - ps: SetUpDCompiler
-  - powershell -Command Invoke-WebRequest https://code.dlang.org/files/dub-1.2.1-windows-x86.zip -OutFile dub.zip
+  - powershell -Command Invoke-WebRequest https://code.dlang.org/files/dub-1.7.1-windows-x86.zip -OutFile dub.zip
   - 7z x dub.zip -odub > nul
   - set PATH=%CD%\%binpath%;%CD%\dub;%PATH%
   - dub --version


### PR DESCRIPTION
We should really start to use a common install script for AppVeyor.