### PR TITLE
remove (pointless?) scope(failure) assert(false)

### DIFF
--- a/tests/tcp/source/app.d
+++ b/tests/tcp/source/app.d
@@ -17,8 +17,6 @@ enum Test {
 
 void test1()
 {
-	scope (failure) assert(false);
-
 	Test test;
 	Task lt;
 


### PR DESCRIPTION
- hides any real backtrace
- test seem flaky (at least failed once on ci.dlang.org, see #2054)