### PR TITLE
Fix wrong proxy mode when creating HTTPReverseProxySettings.

### DIFF
--- a/http/vibe/http/proxy.d
+++ b/http/vibe/http/proxy.d
@@ -279,7 +279,7 @@ final class HTTPProxySettings {
 	bool handleConnectRequests;
 
 	/// Empty default constructor for backwards compatibility - will be deprecated soon.
-	this() { }
+	this() { proxyMode = ProxyMode.reverse; }
 	/// Explicitly sets the proxy mode.
 	this(ProxyMode mode) { proxyMode = mode; }
 }


### PR DESCRIPTION
This is a regression introduced by the forward proxy functionality.