### PR TITLE
Fix deprecations: use atomicOp in examples/bench-http-request

### DIFF
--- a/examples/bench-http-request/source/app.d
+++ b/examples/bench-http-request/source/app.d
@@ -80,7 +80,7 @@ void benchmark()
 		auto tm = sw.peek().msecs;
 		if (nreq >= nreqc && tm >= next_ts) {
 			writefln("%s iterations: %s req/s, %s err/s (%s active conn, %s disconnects/s)", nreq, (nreq*1_000)/tm, (nerr*1_000)/tm, nconn, (ndisconns*1_000)/tm);
-			nreqc += 1000;
+			nreqc.atomicOp!"+="(1000);
 			next_ts += 100;
 		}
 		bool disconnect = ++keep_alives >= g_maxKeepAliveRequests;
@@ -93,9 +93,9 @@ void benchmark()
 void main()
 {
 	import vibe.core.args;
-	readOption("c", &g_concurrency, "The maximum number of concurrent requests");
-	readOption("d", &g_requestDelay, "Artificial request delay in milliseconds");
-	readOption("k", &g_maxKeepAliveRequests, "Maximum number of keep-alive requests for each connection");
+	readOption("c", cast(long*) &g_concurrency, "The maximum number of concurrent requests");
+	readOption("d", cast(long*) &g_requestDelay, "Artificial request delay in milliseconds");
+	readOption("k", cast(long*) &g_maxKeepAliveRequests, "Maximum number of keep-alive requests for each connection");
 	if (!finalizeCommandLineOptions()) return;
 	runTask(toDelegate(&benchmark));
 	runEventLoop();


### PR DESCRIPTION
Yet another deprecation removed.
Note that `std.getopt` doesn't support `shared`.

See also: https://github.com/dlang/dmd/pull/7816