### PR TITLE
Enable Meson on the CI again, now that it's fixed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -52,7 +52,7 @@ matrix:
 
 before_install:
   - pyenv global system 3.6
-  - pip3 install 'git+git://github.com/mesonbuild/meson.git@ca2db0f482e17b89d1b05ad056e4815bac4ad95d'
+  - pip3 install 'meson>=0.44.1'
 
 install:
   - mkdir .ntmp

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ d:
   - dmd-beta
 
 env:
-  - VIBED_DRIVER=libevent PARTS=lint,builds,unittests,examples,tests
+  - VIBED_DRIVER=libevent PARTS=lint,builds,unittests,examples,tests,meson
   - VIBED_DRIVER=vibe-core PARTS=builds,unittests,examples,tests
   - VIBED_DRIVER=libasync PARTS=builds,unittests
 

--- a/travis-ci.sh
+++ b/travis-ci.sh
@@ -4,7 +4,7 @@ set -e -x -o pipefail
 
 DUB_ARGS="--build-mode=${DUB_BUILD_MODE:-separate} ${DUB_ARGS:-}"
 # default to run all parts
-: ${PARTS:=lint,builds,unittests,examples,tests}
+: ${PARTS:=lint,builds,unittests,examples,tests,meson}
 # default to vibe-core driver
 : ${VIBED_DRIVER:=vibe-core}
 


### PR DESCRIPTION
With the Meson 0.44.1 release, all the bugs and annoyances that were happening before regarding subprojects and subproject_dir locations as well as DMD support should be fixed now (and even better: they have a unittest in Meson now).
So, it's safe to re-enable Meson, if this PR builds successfully on the CI.