### PR TITLE
preserve trailing back-slashes in NativePath

### DIFF
--- a/core/vibe/core/path.d
+++ b/core/vibe/core/path.d
@@ -131,6 +131,7 @@ struct Path {
 		m_nodes = splitPath(pathstr);
 		m_absolute = (pathstr.startsWith("/") || m_nodes.length > 0 && (m_nodes[0].toString().canFind(':') || m_nodes[0] == "\\"));
 		m_endsWithSlash = pathstr.endsWith("/");
+		version(Windows) m_endsWithSlash |= pathstr.endsWith(`\`);
 	}
 
 	/// Constructs a path object from a list of PathEntry objects.
@@ -427,6 +428,14 @@ unittest
 		assert(p1.relativeTo(p2).toString() == "");
 		assert(p2.relativeTo(p2).toString() == "./");
 		assert(p2.relativeTo(p1).toString() == "./");
+	}
+
+	// trailing back-slash on Windows
+	version(Windows)
+	{
+		auto winpath = "C:\\windows\\test\\";
+		auto winpathp = Path(winpath);
+		assert(winpathp.toNativeString() == winpath);
 	}
 }
 


### PR DESCRIPTION
Slash behavior originally introduced here vibe-d/vibe.d@970a022#diff-3620332feace439ec637b023bc2e7a01R262, and apparently broken here vibe-d/vibe.d@344fe34#diff-47d6be40e29a186df00d5f3bfad92671R36.

The weird usage of Path for URLs and file paths on Windows makes this difficult to handle properly (though `/` and `\` usage should be mut-ex IIRC). No idea how much impact this breaking change would have. Any suggestion for a better migration path?