### PR TITLE
run tests on ephemeral ports

### DIFF
--- a/tests/rest/source/app.d
+++ b/tests/rest/source/app.d
@@ -450,18 +450,18 @@ class Example7 : Example7API {
 }
 
 
-void runTests()
+void runTests(string url)
 {
 	// Example 1
 	{
-		auto api = new RestInterfaceClient!Example1API("http://127.0.0.1:8080");
+		auto api = new RestInterfaceClient!Example1API(url);
 		assert(api.getSomeInfo() == "Some Info!");
 		assert(api.getter == "Getter");
 		assert(api.postSum(2, 3) == 5);
 	}
 	// Example 2
 	{
-		auto api = new RestInterfaceClient!Example2API("http://127.0.0.1:8080", MethodStyle.upperUnderscored);
+		auto api = new RestInterfaceClient!Example2API(url, MethodStyle.upperUnderscored);
 		Example2API.Aggregate[] data = [
 			{ "one", 1, Example2API.Aggregate.Type.Type1 },
 			{ "two", 2, Example2API.Aggregate.Type.Type2 }
@@ -473,21 +473,21 @@ void runTests()
 	}
 	// Example 3
 	{
-		auto api = new RestInterfaceClient!Example3API("http://127.0.0.1:8080");
+		auto api = new RestInterfaceClient!Example3API(url);
 		assert(api.getMyID(9000) == 9000);
 		assert(api.nestedModule.getNumber() == 42);
 		assert(api.nestedModule.getNumber(1) == 1);
 	}
 	// Example 4
 	{
-		auto api = new RestInterfaceClient!Example4API("http://127.0.0.1:8080");
+		auto api = new RestInterfaceClient!Example4API(url);
 		api.myNameDoesNotMatter();
 		assert(api.getParametersInURL("20", "30") == 50);
 		assert(api.querySpecialParameterNames(10, true) == -10);
 	}
 	// Example 5
 	{
-		auto api = new RestInterfaceClient!Example5API("http://127.0.0.1:8080");
+		auto api = new RestInterfaceClient!Example5API(url);
 		auto secret = api.getSecret(42, User.init);
 		assert(secret == "{secret #42 for admin}");
 	}
@@ -496,9 +496,9 @@ void runTests()
 		import vibe.http.client : requestHTTP;
 		import vibe.stream.operations : readAllUTF8;
 
-		auto api = new RestInterfaceClient!Example6API("http://127.0.0.1:8080");
+		auto api = new RestInterfaceClient!Example6API(url);
 		// First we make sure parameters are transmitted via headers.
-		auto res = requestHTTP("http://127.0.0.1:8080/example6_api/portal",
+		auto res = requestHTTP(url~ "/example6_api/portal",
 		                       (scope r) {
 			r.method = HTTPMethod.GET;
 			r.headers["Authorization"] = "Basic QWxhZGRpbjpvcGVuIHNlc2FtZQ==";
@@ -528,19 +528,19 @@ void runTests()
 		import vibe.stream.operations : readAllUTF8;
 
 		// First we make sure parameters are transmitted via query.
-		auto res = requestHTTP("http://127.0.0.1:8080/example6_api/answer?qparam=Life_universe_and_the_rest",
+		auto res = requestHTTP(url~ "/example6_api/answer?qparam=Life_universe_and_the_rest",
 							   (scope r) { r.method = HTTPMethod.POST; });
 		assert(res.statusCode == 200);
 		assert(res.bodyReader.readAllUTF8() == `"True"`);
 		// Then we check that both can communicate together.
-		auto api = new RestInterfaceClient!Example6API("http://127.0.0.1:8080");
+		auto api = new RestInterfaceClient!Example6API(url);
 		auto answer = api.postAnswer("IDK");
 		assert(answer == "False");
 	}
 
 	// Example 7 -- Custom JSON response
 	{
-		auto api = new RestInterfaceClient!Example7API("http://127.0.0.1:8080");
+		auto api = new RestInterfaceClient!Example7API(url);
 		auto result = api.get();
 		assert(result["foo"] == 42 && result["bar"] == 13);
 	}
@@ -552,10 +552,10 @@ void runTests()
 
 		enum expected = "42fortySomething51.42"; // to!string(51.42) doesn't work at CT
 
-		auto api = new RestInterfaceClient!Example6API("http://127.0.0.1:8080");
+		auto api = new RestInterfaceClient!Example6API(url);
 		{
 			// First we make sure parameters are transmitted via query.
-			auto res = requestHTTP("http://127.0.0.1:8080/example6_api/concat",
+			auto res = requestHTTP(url ~ "/example6_api/concat",
 								   (scope r) {
 							   import vibe.data.json;
 							   r.method = HTTPMethod.POST;
@@ -574,7 +574,7 @@ void runTests()
 		// suppling the whole body
 		{
 			// First we make sure parameters are transmitted via query.
-			auto res = requestHTTP("http://127.0.0.1:8080/example6_api/concat_body",
+			auto res = requestHTTP(url ~ "/example6_api/concat_body",
 								   (scope r) {
 							   import vibe.data.json;
 							   r.method = HTTPMethod.POST;
@@ -606,14 +606,13 @@ shared static this()
 	registerRestInterface(routes, new Example7());
 
 	auto settings = new HTTPServerSettings();
-	settings.port = 8080;
-	settings.bindAddresses = ["::1", "127.0.0.1"];
-
-	listenHTTP(settings, routes);
+	settings.port = 0;
+	settings.bindAddresses = ["127.0.0.1"];
+	immutable serverAddr = listenHTTP(settings, routes).bindAddresses[0];
 
 	runTask({
 		try {
-			runTests();
+			runTests("http://" ~ serverAddr.toString);
 			logInfo("Success.");
 		} catch (Exception e) {
 			import core.stdc.stdlib : exit;

--- a/tests/restclient/source/app.d
+++ b/tests/restclient/source/app.d
@@ -177,10 +177,13 @@ void runTest()
 
 	auto settings = new HTTPServerSettings;
 	settings.disableDistHost = true;
-	settings.port = 8000;
-	listenHTTP(settings, router);
+	settings.port = 0;
+	settings.bindAddresses = ["127.0.0.1"];
+	immutable serverAddr = listenHTTP(settings, router).bindAddresses[0];
 
-	auto api = new RestInterfaceClient!ITestAPI("http://127.0.0.1:8000/root/");
+	immutable url = "http://" ~ serverAddr.toString;
+
+	auto api = new RestInterfaceClient!ITestAPI(url ~ "/root/");
 	assert(api.getInfo() == "description");
 	assert(api.info() == "description2");
 	assert(api.customParameters("one", "two") == "onetwo");
@@ -192,19 +195,19 @@ void runTest()
 	assert(api.sub.get(5) == 5);
 	assert(api.testKeyword(3, 4) == 7);
 
-	assertCorsFails("http://127.0.0.1:8000/cors1/foo", HTTPMethod.GET, "www.non-existent.com");
-	assertCorsPasses("http://127.0.0.1:8000/cors1/foo", HTTPMethod.GET, "www.foobar.com");
-	assertCorsPasses("http://127.0.0.1:8000/cors1/foo", HTTPMethod.GET, "www.example.com");
-	assertCorsPasses("http://127.0.0.1:8000/cors2/foo", HTTPMethod.GET, "www.abcdefg.com");
-	assertCorsPasses("http://127.0.0.1:8000/cors3/foo", HTTPMethod.GET, "www.foobar.com");
-	assertCorsFails("http://127.0.0.1:8000/cors3/foo", HTTPMethod.GET, "www.bazbaz.com");
+	assertCorsFails(url ~ "/cors1/foo", HTTPMethod.GET, "www.non-existent.com");
+	assertCorsPasses(url ~ "/cors1/foo", HTTPMethod.GET, "www.foobar.com");
+	assertCorsPasses(url ~ "/cors1/foo", HTTPMethod.GET, "www.example.com");
+	assertCorsPasses(url ~ "/cors2/foo", HTTPMethod.GET, "www.abcdefg.com");
+	assertCorsPasses(url ~ "/cors3/foo", HTTPMethod.GET, "www.foobar.com");
+	assertCorsFails(url ~ "/cors3/foo", HTTPMethod.GET, "www.bazbaz.com");
 
-	testAllowHeader("http://127.0.0.1:8000/cors1/foo",   [HTTPMethod.GET,HTTPMethod.PUT,HTTPMethod.POST]);
-	testAllowHeader("http://127.0.0.1:8000/cors1/bar/6", [HTTPMethod.POST,HTTPMethod.DELETE,HTTPMethod.PATCH]);
-	testAllowHeader("http://127.0.0.1:8000/cors1/7/foo", [HTTPMethod.PUT,HTTPMethod.POST,HTTPMethod.DELETE]);
-	testCors("http://127.0.0.1:8000/cors1/foo", 			[HTTPMethod.GET,HTTPMethod.PUT,HTTPMethod.POST]);
-	testCors("http://127.0.0.1:8000/cors1/bar/6", 		[HTTPMethod.POST,HTTPMethod.DELETE,HTTPMethod.PATCH]);
-	testCors("http://127.0.0.1:8000/cors1/7/foo", 		[HTTPMethod.PUT,HTTPMethod.POST,HTTPMethod.DELETE]);
+	testAllowHeader(url ~ "/cors1/foo",   [HTTPMethod.GET,HTTPMethod.PUT,HTTPMethod.POST]);
+	testAllowHeader(url ~ "/cors1/bar/6", [HTTPMethod.POST,HTTPMethod.DELETE,HTTPMethod.PATCH]);
+	testAllowHeader(url ~ "/cors1/7/foo", [HTTPMethod.PUT,HTTPMethod.POST,HTTPMethod.DELETE]);
+	testCors(url ~ "/cors1/foo", 			[HTTPMethod.GET,HTTPMethod.PUT,HTTPMethod.POST]);
+	testCors(url ~ "/cors1/bar/6", 		[HTTPMethod.POST,HTTPMethod.DELETE,HTTPMethod.PATCH]);
+	testCors(url ~ "/cors1/7/foo", 		[HTTPMethod.PUT,HTTPMethod.POST,HTTPMethod.DELETE]);
 
 	exitEventLoop(true);
 }

--- a/tests/restcollections/source/app.d
+++ b/tests/restcollections/source/app.d
@@ -90,11 +90,12 @@ void runTest()
 	router.registerRestInterface(new LocalAPI);
 
 	auto settings = new HTTPServerSettings;
+	settings.port = 0;
+	settings.bindAddresses = ["127.0.0.1"];
 	settings.disableDistHost = true;
-	settings.port = 8000;
-	listenHTTP(settings, router);
+	immutable serverAddr = listenHTTP(settings, router).bindAddresses[0];
 
-	auto api = new RestInterfaceClient!API("http://127.0.0.1:8000/");
+	auto api = new RestInterfaceClient!API("http://" ~ serverAddr.toString);
 	assert(api.items["foo"].subItems.length == 2);
 	assert(api.items["foo"].subItems[0].name == "hello");
 	assert(api.items["foo"].subItems[1].name == "world");

--- a/tests/tcpproxy/source/app.d
+++ b/tests/tcpproxy/source/app.d
@@ -38,6 +38,9 @@ void testProtocol(TCPConnection server, bool terminate)
 
 void runTest()
 {
+	import std.algorithm : find;
+	import std.socket : AddressFamily;
+
 	// server for a simple line based protocol
 	auto l1 = listenTCP(0, (client) {
 		while (!client.empty) {
@@ -50,7 +53,7 @@ void runTest()
 
 			client.write(format("Hash: %08X\r\n", typeid(string).getHash(&ln)));
 		}
-	})[0];
+	}).find!(l => l.bindAddress.family == AddressFamily.INET).front;
 	scope (exit) l1.stopListening;
 
 	// proxy server
@@ -71,7 +74,7 @@ void runTest()
 		}
 		server.write(client);
 		logInfo("Proxy out");
-	})[0];
+	}).find!(l => l.bindAddress.family == AddressFamily.INET).front;
 	scope (exit) l2.stopListening;
 
 	// test server

--- a/tests/vibe.core.net.1726/source/app.d
+++ b/tests/vibe.core.net.1726/source/app.d
@@ -7,7 +7,7 @@ ubyte[] buf;
 
 void performTest(bool reverse)
 {
-	auto l = listenTCP(11375, (conn) {
+	auto l = listenTCP(0, (conn) {
 		bool read_ex = false;
 		bool write_ex = false;
 		auto rt = runTask!TCPConnection((conn) {
@@ -42,7 +42,7 @@ void performTest(bool reverse)
 
 	runTask({
 		try {
-			auto conn = connectTCP("127.0.0.1", 11375);
+			auto conn = connectTCP(l.bindAddress);
 			sleep(reverse ? 20.msecs : 100.msecs);
 			conn.close();
 		} catch (Exception e) assert(false, e.msg);

--- a/tests/vibe.http.client.1426/source/app.d
+++ b/tests/vibe.http.client.1426/source/app.d
@@ -5,12 +5,12 @@ import vibe.stream.operations;
 
 shared static this()
 {
-	listenTCP(11426, (TCPConnection c) {
+	immutable serverAddr = listenTCP(0, (TCPConnection c) {
 		c.write("HTTP/1.1 200 OK\r\nConnection: Close\r\n\r\nqwerty");
-	}, "127.0.0.1");
+	}, "127.0.0.1").bindAddress;
 
 	runTask({
-		requestHTTP("http://127.0.0.1:11426",
+		requestHTTP("http://" ~ serverAddr.toString,
 			(scope req) {},
 			(scope res) {
 				assert(res.bodyReader.readAllUTF8() == "qwerty");

--- a/tests/vibe.http.server.1388/source/app.d
+++ b/tests/vibe.http.server.1388/source/app.d
@@ -9,12 +9,12 @@ void main()
 {
 	version (none) {
 	auto s1 = new HTTPServerSettings;
+	s1.port = 0;
 	s1.bindAddresses = ["::1"];
-	s1.port = 11388;
-	listenHTTP(s1, &handler);
+	immutable serverAddr = listenHTTP(s1, &handler).bindAddresses[0];
 
 	runTask({
-		auto conn = connectTCP("::1", 11388);
+		auto conn = connectTCP(serverAddr);
 		conn.write("GET / HTTP/1.1\r\nHost: [::1]\r\n\r\n");
 		string res = cast(string)conn.readLine();
 		assert(res == "HTTP/1.1 200 OK", res);
@@ -35,7 +35,7 @@ void main()
 	}
 
 	import vibe.core.log : logWarn;
-	logWarn("Test disabled due to issues listening on ::1 on Travis-CI");
+	logWarn("Test disabled due to missing IPv6 support (loopback) on Travis-CI");
 }
 
 void handler(scope HTTPServerRequest req, scope HTTPServerResponse res)

--- a/tests/vibe.http.server.1721/source/app.d
+++ b/tests/vibe.http.server.1721/source/app.d
@@ -11,15 +11,15 @@ shared static this()
 {
 	auto s1 = new HTTPServerSettings;
 	s1.options &= ~HTTPServerOption.errorStackTraces;
+	s1.port = 0;
 	s1.bindAddresses = ["127.0.0.1"];
-	s1.port = 11721;
-	listenHTTP(s1, &handler);
+	immutable serverAddr = listenHTTP(s1, &handler).bindAddresses[0];
 
 	runTask({
 		scope (exit) exitEventLoop();
 
 		try {
-			auto conn = connectTCP("127.0.0.1", 11721);
+			auto conn = connectTCP(serverAddr);
 			conn.write("GET / HTTP/1.0\r\n\r\n");
 			string res = cast(string)conn.readLine();
 			assert(res == "HTTP/1.0 200 OK", res);

--- a/tests/vibe.http.server.host-header/source/app.d
+++ b/tests/vibe.http.server.host-header/source/app.d
@@ -10,13 +10,13 @@ shared static this()
 {
 	auto s1 = new HTTPServerSettings;
 	s1.options &= ~HTTPServerOption.errorStackTraces;
+	s1.port = 0;
 	s1.bindAddresses = ["127.0.0.1"];
-	s1.port = 11388;
-	listenHTTP(s1, &handler);
+	immutable serverAddr = listenHTTP(s1, &handler).bindAddresses[0];
 
 	runTask({
 		try {
-			auto conn = connectTCP("127.0.0.1", 11388);
+			auto conn = connectTCP(serverAddr);
 			conn.write("GET / HTTP/1.1\r\nHost: 127.0.0.1\r\n\r\n");
 			string res = cast(string)conn.readLine();
 			assert(res == "HTTP/1.1 200 OK", res);
@@ -37,7 +37,7 @@ shared static this()
 			assert(!conn.connected);
 			logInfo("1.1 without Host header OK.");
 
-			conn = connectTCP("127.0.0.1", 11388);
+			conn = connectTCP(serverAddr);
 			conn.write("GET / HTTP/1.0\r\n\r\n");
 			res = cast(string)conn.readLine();
 			assert(res == "HTTP/1.0 200 OK", res);

--- a/tests/vibe.http.server.listenHTTP/source/app.d
+++ b/tests/vibe.http.server.listenHTTP/source/app.d
@@ -4,17 +4,19 @@ import vibe.core.log;
 import vibe.http.client;
 import vibe.http.server;
 import vibe.stream.operations : readAllUTF8;
+import std.algorithm : find;
+import std.socket : AddressFamily;
 
 shared static this()
 {
-	listenHTTP(":11721", (scope req, scope res) {
+	immutable serverAddr = listenHTTP(":0", (scope req, scope res) {
 		res.writeBody("Hello world.");
-	});
+	}).bindAddresses.find!(addr => addr.family == AddressFamily.INET).front;
 
 	runTask({
 		scope (exit) exitEventLoop();
 
-		auto res = requestHTTP("http://0.0.0.0:11721");
+		auto res = requestHTTP("http://" ~ serverAddr.toString);
 		assert(res.statusCode == HTTPStatus.ok);
 		assert(res.bodyReader.readAllUTF8 == "Hello world.");
 		logInfo("All web tests succeeded.");

--- a/tests/vibe.http.websocket/source/app.d
+++ b/tests/vibe.http.websocket/source/app.d
@@ -7,20 +7,19 @@ import vibe.http.websockets;
 shared static this()
 {
 	auto settings = new HTTPServerSettings;
-	// 10k + issue number -> Avoid bind errors
-	settings.port = 11332;
-	settings.bindAddresses = ["::1", "127.0.0.1"];
-	listenHTTP(settings, handleWebSockets((scope ws) {
+	settings.port = 0;
+	settings.bindAddresses = ["127.0.0.1"];
+	immutable serverAddr = listenHTTP(settings, handleWebSockets((scope ws) {
 		assert(ws.receiveText() == "foo");
 		ws.send("hello");
 		assert(ws.receiveText() == "bar");
 		ws.close();
-	}));
+	})).bindAddresses[0];
 
 	runTask({
 		scope(exit) exitEventLoop(true);
 
-		connectWebSocket(URL("http://127.0.0.1:11332/"), (scope ws) {
+		connectWebSocket(URL("http://" ~ serverAddr.toString), (scope ws) {
 			ws.send("foo");
 			assert(ws.receiveText() == "hello");
 			ws.send("bar");

--- a/tests/vibe.web.rest.1125/source/app.d
+++ b/tests/vibe.web.rest.1125/source/app.d
@@ -4,18 +4,17 @@ import std.datetime;
 shared static this()
 {
 	auto settings = new HTTPServerSettings;
-    // 10k + issue number -> Avoid bind errors
-	settings.port = 11125;
-	settings.bindAddresses = ["::1", "127.0.0.1"];
-    auto router = new URLRouter;
-    router.registerRestInterface(new Llama);
-    listenHTTP(settings, router);
+	settings.port = 0;
+	settings.bindAddresses = ["127.0.0.1"];
+	auto router = new URLRouter;
+	router.registerRestInterface(new Llama);
+	immutable serverAddr = listenHTTP(settings, router).bindAddresses[0];
 
     // Client
     setTimer(1.seconds, {
             scope(exit) exitEventLoop(true);
 
-            auto api = new RestInterfaceClient!ILlama("http://127.0.0.1:11125/");
+            auto api = new RestInterfaceClient!ILlama("http://"~serverAddr.toString);
             auto r = api.updateLlama("llama");
             assert(r == "llama", "[vibe.web.rest.1125.Client] Expected llama, got: " ~ r);
         });

--- a/tests/vibe.web.rest.1140/source/app.d
+++ b/tests/vibe.web.rest.1140/source/app.d
@@ -47,18 +47,16 @@ enum Param3 = 1;
 shared static this()
 {
 	auto settings = new HTTPServerSettings;
-    // 10k + issue number -> Avoid bind errors
-	settings.port = 11140;
-	settings.bindAddresses = ["::1", "127.0.0.1"];
-
+	settings.port = 0;
+	settings.bindAddresses = ["127.0.0.1"];
 	auto router = new URLRouter;
 	router.registerRestInterface(new OrientDBRoot);
-	listenHTTP(settings, router);
+	immutable serverAddr = listenHTTP(settings, router).bindAddresses[0];
 
 	setTimer(1.seconds, {
 			scope (exit) exitEventLoop(true);
 			auto api = new RestInterfaceClient!IOrientDBRoot(
-				"http://127.0.0.1:11140/");
+				"http://"~serverAddr.toString);
 			api.query.sql(Param1, Param2, Param3);
 			api.query.sql2(Param1, Param2ALT, Param3);
 		});

--- a/tests/vibe.web.rest.auth/source/app.d
+++ b/tests/vibe.web.rest.auth/source/app.d
@@ -17,18 +17,18 @@ import std.format : format;
 shared static this()
 {
 	auto settings = new HTTPServerSettings;
-	settings.port = 9128;
-	settings.bindAddresses = ["::1", "127.0.0.1"];
-    auto router = new URLRouter;
-    router.registerRestInterface(new Service);
-    listenHTTP(settings, router);
+	settings.port = 0;
+	settings.bindAddresses = ["127.0.0.1"];
+	auto router = new URLRouter;
+	router.registerRestInterface(new Service);
+	immutable serverAddr = listenHTTP(settings, router).bindAddresses[0];
 
     runTask({
         scope (exit) exitEventLoop();
 
         void test(string url, string user, HTTPStatus expected)
         {
-            requestHTTP("http://127.0.0.1:9128"~url, (scope req) {
+            requestHTTP("http://" ~ serverAddr.toString ~ url, (scope req) {
                 if (user !is null) req.addBasicAuth(user, "secret");
             }, (scope res) {
                 res.dropBody();

--- a/tests/vibe.web.web.auth/source/app.d
+++ b/tests/vibe.web.web.auth/source/app.d
@@ -17,11 +17,11 @@ import std.format : format;
 shared static this()
 {
 	auto settings = new HTTPServerSettings;
-	settings.port = 9128;
-	settings.bindAddresses = ["::1", "127.0.0.1"];
-    auto router = new URLRouter;
-    router.registerWebInterface(new Service);
-    listenHTTP(settings, router);
+	settings.port = 0;
+	settings.bindAddresses = ["127.0.0.1"];
+	auto router = new URLRouter;
+	router.registerWebInterface(new Service);
+	immutable serverAddr = listenHTTP(settings, router).bindAddresses[0];
 
     runTask({
         scope (exit) exitEventLoop();
@@ -29,7 +29,7 @@ shared static this()
         void test(string url, string user, HTTPStatus expected)
         nothrow {
             try {
-                requestHTTP("http://127.0.0.1:9128"~url, (scope req) {
+                requestHTTP("http://" ~ serverAddr.toString ~ url, (scope req) {
                     if (user !is null) req.addBasicAuth(user, "secret");
                 }, (scope res) {
                     res.dropBody();

--- a/tests/vibe.web.web/source/app.d
+++ b/tests/vibe.web.web/source/app.d
@@ -13,19 +13,17 @@ import std.format : format;
 shared static this()
 {
 	auto settings = new HTTPServerSettings;
+	settings.port = 0;
 	settings.bindAddresses = ["127.0.0.1"];
-	settings.port = 9132;
-
 	auto router = new URLRouter;
 	router.registerWebInterface(new Service);
-
-	listenHTTP(settings, router);
+	immutable serverAddr = listenHTTP(settings, router).bindAddresses[0];
 
 	runTask({
 		scope (exit) exitEventLoop();
 
 		void test(string url, HTTPStatus expected) {
-			requestHTTP("http://127.0.0.1:9132"~url,
+			requestHTTP("http://" ~ serverAddr.toString ~ url,
 				(scope req) {
 				},
 				(scope res) {


### PR DESCRIPTION
- for obvious reasons
- dropped IPv6 binds as requestHTTP to IPv6 addresses doesn't work (#2080)
  (also IPv6 support should be tested once, not everywhere)