### PR TITLE
Add std.uuid.UUID serialization to strings for Json.

### DIFF
--- a/data/vibe/data/json.d
+++ b/data/vibe/data/json.d
@@ -1727,12 +1727,15 @@ unittest {
 	}
 
 	const u = UUID("318d7a61-e41b-494e-90d3-0a99f5531bfe");
-	auto s = `{"v":"318d7a61-e41b-494e-90d3-0a99f5531bfe"}`;
+	const s = `{"v":"318d7a61-e41b-494e-90d3-0a99f5531bfe"}`;
 	auto j = Json(["v": Json(u)]);
 
 	const v = V(u);
 
 	assert(serializeToJson(v) == j);
+
+	j = Json.emptyObject;
+	j["v"] = u;
 	assert(deserializeJson!V(j).v == u);
 
 	assert(serializeToJsonString(v) == s);

--- a/data/vibe/data/json.d
+++ b/data/vibe/data/json.d
@@ -199,8 +199,6 @@ struct Json {
 	/// ditto
 	this(string v) @trusted { m_type = Type.string; m_string = v; }
 	/// ditto
-	this(UUID v) { this(v.toString()); }
-	/// ditto
 	this(Json[] v) @trusted { m_type = Type.array; m_array = v; }
 	/// ditto
 	this(Json[string] v) @trusted { m_type = Type.object; m_object = v; }


### PR DESCRIPTION
Not sure about the proper approach to adding this in, but this passes the tests for me.

I personally am using `UUID`s as part of a REST API and supporting this avoids a large amount of parsing I have to do manually right now.