### PR TITLE
String enum as form parameter is treated as an array of `immutable(char)`

### DIFF
--- a/web/vibe/web/common.d
+++ b/web/vibe/web/common.d
@@ -802,7 +802,7 @@ package void setVoid(T, U)(ref T dst, U value)
 unittest {
 	static assert(!__traits(compiles, { bool[] barr; ParamError err;readFormParamRec(null, barr, "f", true, NestedNameStyle.d, err); }));
 	static assert(__traits(compiles, { bool[2] barr; ParamError err;readFormParamRec(null, barr, "f", true, NestedNameStyle.d, err); }));
-	
+
 	enum Test: string {	a = "AAA", b="BBB" }
 	static assert(__traits(compiles, { Test barr; ParamError err;readFormParamRec(null, barr, "f", true, NestedNameStyle.d, err); }));
 }

--- a/web/vibe/web/common.d
+++ b/web/vibe/web/common.d
@@ -802,6 +802,9 @@ package void setVoid(T, U)(ref T dst, U value)
 unittest {
 	static assert(!__traits(compiles, { bool[] barr; ParamError err;readFormParamRec(null, barr, "f", true, NestedNameStyle.d, err); }));
 	static assert(__traits(compiles, { bool[2] barr; ParamError err;readFormParamRec(null, barr, "f", true, NestedNameStyle.d, err); }));
+	
+	enum Test: string {	a = "AAA", b="BBB" }
+	static assert(__traits(compiles, { Test barr; ParamError err;readFormParamRec(null, barr, "f", true, NestedNameStyle.d, err); }));
 }
 
 private string getArrayFieldName(T)(NestedNameStyle style, string prefix, T index)

--- a/web/vibe/web/common.d
+++ b/web/vibe/web/common.d
@@ -692,7 +692,7 @@ package ParamResult readFormParamRec(T)(scope HTTPServerRequest req, ref T dst, 
 	import std.typecons;
 	import vibe.data.serialization;
 
-	static if (isDynamicArray!T && !isSomeString!T) {
+	static if (isDynamicArray!T && !(isSomeString!T || is(T: string))) {
 		alias EL = typeof(T.init[0]);
 		static assert(!is(EL == bool),
 			"Boolean arrays are not allowed, because their length cannot " ~

--- a/web/vibe/web/common.d
+++ b/web/vibe/web/common.d
@@ -692,7 +692,7 @@ package ParamResult readFormParamRec(T)(scope HTTPServerRequest req, ref T dst, 
 	import std.typecons;
 	import vibe.data.serialization;
 
-	static if (isDynamicArray!T && !(isSomeString!T || is(T: string))) {
+	static if (isDynamicArray!T && !isSomeString!(OriginalType!T)) {
 		alias EL = typeof(T.init[0]);
 		static assert(!is(EL == bool),
 			"Boolean arrays are not allowed, because their length cannot " ~


### PR DESCRIPTION
Using a string enum as parameter in a web interface results in build failure.

Example:
```d
import vibe.d;

enum StrEnum{
	a = "hello", b = "world"
}
class WebIface{
	void getTest(StrEnum param){}
}

void main(){
	import std.traits;
	pragma(msg, "StrEnum is dynamic array: ", isDynamicArray!StrEnum);
	pragma(msg, "StrEnum is some string: ", isSomeString!StrEnum);

	auto router = new URLRouter;
	router.registerWebInterface(new WebIface);
}
```
Outputs:
```
StrEnum is dynamic array: true
StrEnum is some string: false
vibe-d-0.8.3-rc.1/vibe-d/web/vibe/web/common.d(799,9): Error: cannot modify `immutable` expression `dst`
vibe-d-0.8.3-rc.1/vibe-d/web/vibe/web/common.d(773,15): Error: template instance `vibe.web.common.setVoid!(immutable(char), immutable(char))` error instantiating
vibe-d-0.8.3-rc.1/vibe-d/web/vibe/web/common.d(737,23):        instantiated from here: `webConvTo!(immutable(char))`
vibe-d-0.8.3-rc.1/vibe-d/web/vibe/web/common.d(704,29):        instantiated from here: `readFormParamRec!(immutable(char))`
vibe-d-0.8.3-rc.1/vibe-d/web/vibe/web/web.d(927,40):        instantiated from here: `readFormParamRec!(StrEnum)`
vibe-d-0.8.3-rc.1/vibe-d/web/vibe/web/web.d(185,34):        instantiated from here: `handleRequest!("getTest", getTest, WebIface)`
source/app.d(16,29):        instantiated from here: `registerWebInterface!(WebIface, cast(MethodStyle)5)`
```

This is due to [this condition](https://github.com/vibe-d/vibe.d/blob/master/web/vibe/web/common.d#L695) being true when the variable is an enum with string as the underlying type.

This means the parameter is treated as an array of `immutable(char)`, and cause later failure when it tries to set an immutable value (I don't know if it's intended, but immutable form parameters always produce this "set immutable" error)

This change fixed the issue for my use case, but it could have some naughty side effects that I haven't  thought of.