### PR TITLE
Make openssl-1.1 the new default

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,15 +210,15 @@ Optionally, run `./setup-freebsd.sh` to create a user/group pair for privilege l
 Switching between OpenSSL versions
 ----------------------------------
 
-By default, vibe.d is built against OpenSSL 1.0.x. On systems that use the newer
-1.1.x branch, this can be overridden on the DUB command line using
-`--override-config vibe-d:tls/openssl-1.1`. Alternatively, the same can be done
+By default, vibe.d is built against OpenSSL 1.1.x. On systems that use the older
+1.0.x branch, this can be overridden on the DUB command line using
+`--override-config vibe-d:tls/openssl-1.0`. Alternatively, the same can be done
 using a sub configuration directive in the package recipe:
 
 SDL syntax:
 ```
 dependency "vibe-d:tls" version="~>0.8.2"
-subConfiguration "vibe-d:tls" "openssl-1.1"
+subConfiguration "vibe-d:tls" "openssl-1.0"
 ```
 
 JSON syntax:

--- a/tls/dub.sdl
+++ b/tls/dub.sdl
@@ -19,15 +19,15 @@ configuration "openssl-mscoff" {
 	sourceFiles "../lib/win-amd64/libeay32.lib" "../lib/win-amd64/ssleay32.lib" platform="windows-x86_64"
 }
 
-configuration "openssl" {
-	sourceFiles "../lib/win-i386/eay.lib" "../lib/win-i386/ssl.lib" platform="windows-x86-dmd"
-	dependency "openssl" version="~>1.0"
-}
-
 configuration "openssl-1.1" {
 	platforms "posix"
 	dependency "openssl" version="~>1.0"
 	versions "VibeUseOpenSSL11"
+}
+
+configuration "openssl-1.0" {
+	sourceFiles "../lib/win-i386/eay.lib" "../lib/win-i386/ssl.lib" platform="windows-x86-dmd"
+	dependency "openssl" version="~>1.0"
 }
 
 configuration "openssl-0.9" {


### PR DESCRIPTION
Always using `--override-config="vibe-d:tls/openssl-1.1"` is really annoying and
OpenSSL 1.1 was released almost two years ago, so it's available on all major Linux distros.

https://www.openssl.org/news/openssl-1.1.0-notes.html

Even Debian (!) transitioned to OpenSSL 1.1:

https://wiki.debian.org/OpenSSL-1.1