### PR TITLE
Make the legacy Path.bySegment semantically compatible with vibe-core.

### DIFF
--- a/core/vibe/core/path.d
+++ b/core/vibe/core/path.d
@@ -152,7 +152,11 @@ struct Path {
 	@property bool absolute() const { return m_absolute; }
 
 	/// Forward compatibility property for vibe-code
-	@property immutable(PathEntry)[] bySegment() const { return nodes; }
+	@property immutable(PathEntry)[] bySegment()
+	const {
+		if (m_absolute) return PathEntry("") ~ nodes;
+		else return nodes;
+	}
 
 	/// Resolves all '.' and '..' path entries as far as possible.
 	void normalize()
@@ -436,6 +440,24 @@ unittest
 		auto winpath = "C:\\windows\\test\\";
 		auto winpathp = Path(winpath);
 		assert(winpathp.toNativeString() == winpath);
+	}
+}
+
+
+unittest {
+	import std.algorithm.comparison : equal;
+	import std.range : only;
+
+	assert(Path("/foo/").bySegment.equal(
+		only(Path.Segment(""), Path.Segment("foo"))
+	));
+	assert(Path("foo/").bySegment.equal(
+		only(Path.Segment("foo"))
+	));
+	version (Windows) {
+		assert(Path("C:\\foo\\").bySegment.equal(
+			only(Path.Segment(""), Path.Segment("C:"), Path.Segment("foo"))
+		));
 	}
 }
 

--- a/core/vibe/core/path.d
+++ b/core/vibe/core/path.d
@@ -152,10 +152,17 @@ struct Path {
 	@property bool absolute() const { return m_absolute; }
 
 	/// Forward compatibility property for vibe-code
-	@property immutable(PathEntry)[] bySegment()
-	const {
-		if (m_absolute) return PathEntry("") ~ nodes;
-		else return nodes;
+	@property auto bySegment()
+	const @nogc {
+		import std.range : chain;
+
+		if (m_absolute) {
+			static immutable emptyseg = [PathEntry("")];
+			return chain(emptyseg[], nodes);
+		} else {
+			static immutable PathEntry[] noseg;
+			return chain(noseg[], nodes);
+		}
 	}
 
 	/// Resolves all '.' and '..' path entries as far as possible.
@@ -239,7 +246,7 @@ struct Path {
 	@property Path parentPath() const { return this[0 .. length-1]; }
 
 	/// The ist of path entries of which this path is composed
-	@property immutable(PathEntry)[] nodes() const { return m_nodes; }
+	@property immutable(PathEntry)[] nodes() const @nogc { return m_nodes; }
 
 	/// The number of path entries of which this path is composed
 	@property size_t length() const { return m_nodes.length; }


### PR DESCRIPTION
Prepends an empty path segment for absolute paths, so that the segment representation of the path is the same as for vibe-core.

See also dlang/dub-registry#318.