### PR TITLE
fix Bson.opEquals: order of object keys is not determined

### DIFF
--- a/data/vibe/data/bson.d
+++ b/data/vibe/data/bson.d
@@ -754,12 +754,28 @@ struct Bson {
 	///
 	bool opEquals(ref const Bson other) const {
 		if( m_type != other.m_type ) return false;
-		return m_data == other.m_data;
+		if (m_type != Type.object)
+			return m_data == other.m_data;
+
+		if (m_data == other.m_data)
+			return true;
+		// Similar objects can have a different key order, but they must have a same length
+		if (m_data.length != other.m_data.length)
+			return false;
+
+		foreach (k, ref v; this.byKeyValue)
+		{
+			if (other[k] != v)
+				return false;
+		}
+
+		return true;
 	}
 	/// ditto
 	bool opEquals(const Bson other) const {
 		if( m_type != other.m_type ) return false;
-		return m_data == other.m_data;
+
+		return opEquals(other);
 	}
 
 	private void checkType(in Type[] valid_types...)


### PR DESCRIPTION
Subj. This PR is needed for [druntime#2243](https://github.com/dlang/druntime/pull/2243)
If it is possible, make a new tag if this will be approved, please.