### PR TITLE
In vibe.utils.hashmap fix equals for Object keys and fix special case for Object.toHash

### DIFF
--- a/core/vibe/core/drivers/libevent2.d
+++ b/core/vibe/core/drivers/libevent2.d
@@ -693,7 +693,20 @@ struct ThreadSlot {
 	ArraySet!Task tasks;
 }
 /// private
-alias ThreadSlotMap = HashMap!(Thread, ThreadSlot);
+struct ThreadSlotMapTraits {
+	enum Thread clearValue = null;
+	// This relies on no subclass of Thread overriding opEquals or toHash.
+	static bool equals(in Thread a, in Thread b)
+	@nogc nothrow pure @safe {
+		return a is b;
+	}
+	static size_t hashOf(in Thread a)
+	@nogc nothrow pure @trusted {
+		return cast(size_t) cast(const void*) a;
+	}
+}
+/// private
+alias ThreadSlotMap = HashMap!(Thread, ThreadSlot, ThreadSlotMapTraits);
 
 final class Libevent2ManualEvent : Libevent2Object, ManualEvent {
 @safe:


### PR DESCRIPTION
**EDIT: The description is talking about DefaultHashMapTraits.hashOf since that's what the PR was originally about.**

Before the condition was improperly written (`&Object.init.toHash is &T.init.toHash` instead of `&Object.toHash is &T.toHash`) so it never triggered:

https://run.dlang.io/is/yLG7gs
```d
void main()
{
    static assert(&Object.toHash is &Object.toHash); // Passes.
    static assert(&Object.init.toHash is &Object.init.toHash); // Doesn't pass!
}
```

But it's a good thing the condition didn't trigger because it also didn't check that the class was `final`:

https://run.dlang.io/is/BFkjFJ
```d
void main()
{
    static class C1 {}
    static class C2 : C1 { override size_t toHash() { return 4; } }
    static assert(&C2.toHash !is &Object.toHash);
    static assert(&C1.toHash is &Object.toHash); // Uh-oh! Passes!
}
```

This PR fixes both problems so the special case now works as intended. Also the use of `Unqual` was unnecessary so it was removed.

**__EDIT:__ Also fixes `DefaultHashMapTraits.equals` for classes that override `opEquals`.**