### PR TITLE
Fix RestInterfaceSettings.dup() for errorHandler callback

### DIFF
--- a/http/vibe/http/client.d
+++ b/http/vibe/http/client.d
@@ -268,6 +268,16 @@ class HTTPClientSettings {
 		Note that this overrides a callback set with `HTTPClient.setTLSContextSetup`.
 	*/
 	void delegate(TLSContext ctx) @safe nothrow tlsContextSetup;
+
+	@property HTTPClientSettings dup()
+	const @safe {
+		auto ret = new HTTPClientSettings;
+		ret.proxyURL = this.proxyURL;
+		ret.networkInterface = this.networkInterface;
+		ret.dnsAddressFamily = this.dnsAddressFamily;
+		ret.tlsContextSetup = this.tlsContextSetup;
+		return ret;
+	}
 }
 
 ///

--- a/web/vibe/web/rest.d
+++ b/web/vibe/web/rest.d
@@ -819,6 +819,10 @@ class RestInterfaceSettings {
 		ret.methodStyle = this.methodStyle;
 		ret.stripTrailingUnderscore = this.stripTrailingUnderscore;
 		ret.allowedOrigins = this.allowedOrigins.dup;
+		ret.errorHandler = this.errorHandler;
+		if (this.httpClientSettings) {
+			ret.httpClientSettings = this.httpClientSettings.dup;
+		}
 		return ret;
 	}
 }


### PR DESCRIPTION
Added missing fields copy in RestInterfaceSettings.dup().

Without this, setting `errorHandler` callback will not work because
of this in `module vibe.web.internal.rest.common:L118`
```D
this.settings = settings ? settings.dup : new RestInterfaceSettings;
```