### PR TITLE
fix returning hostname from uname on posix

### DIFF
--- a/core/vibe/core/log.d
+++ b/core/vibe/core/log.d
@@ -685,11 +685,11 @@ private string hostName()
 	string hostName;
 
 	version (Posix) {
-		import core.sys.posix.sys.utsname;
+		import core.sys.posix.sys.utsname : uname, utsname;
 		import core.sys.posix.unistd : gethostname;
 		utsname name;
 		if (uname(&name)) return hostName;
-		hostName = name.nodename.to!string();
+		hostName = name.nodename.ptr.to!string;
 
 		import std.socket;
 		auto ih = new InternetHost;


### PR DESCRIPTION
As seen in [documentation](http://man7.org/linux/man-pages/man2/uname.2.html) `nodename` is `char[]` of unspecified size and string is null terminated.

There is specified size of 65 in [druntime](https://github.com/dlang/druntime/blob/a59c3832fc00ab127018d9a570ba03520437524f/src/core/sys/posix/sys/utsname.d#L22).

But `to!string` on the char array doesn't handle null terminated string but just returns it in a full length with nulls.

I've found this out on one of the servers where something strange was logged and it was exactly 65 chars in length.

Fixed it using `std.string.fromStringz`.

**Note**: This should be fixed in [vibe-core](https://github.com/vibe-d/vibe-core/blob/6ca6dd16d4f89c1a8d3bb89fa58d56cf466d70e6/source/vibe/core/log.d#L739) too