### PR TITLE
Fix/modernize a few HTTP server examples.

### DIFF
--- a/examples/http_server/dub.json
+++ b/examples/http_server/dub.json
@@ -1,8 +1,0 @@
-{
-	"name": "http-server-example",
-	"description": "A minimal HTTP server.",
-	"dependencies": {
-		"vibe-d:http": {"path": "../../"}
-	},
-	"versions": ["VibeDefaultMain"]
-}

--- a/examples/http_server/dub.sdl
+++ b/examples/http_server/dub.sdl
@@ -1,0 +1,3 @@
+name "http-server-example"
+description "A minimal HTTP server."
+dependency "vibe-d:http" path="../../"

--- a/examples/http_server/source/app.d
+++ b/examples/http_server/source/app.d
@@ -1,4 +1,4 @@
-import vibe.appmain;
+import vibe.core.core : runApplication;
 import vibe.http.server;
 
 void handleRequest(scope HTTPServerRequest req, scope HTTPServerResponse res)
@@ -7,11 +7,14 @@ void handleRequest(scope HTTPServerRequest req, scope HTTPServerResponse res)
 		res.writeBody("Hello, World!", "text/plain");
 }
 
-shared static this()
+void main()
 {
 	auto settings = new HTTPServerSettings;
 	settings.port = 8080;
 	settings.bindAddresses = ["::1", "127.0.0.1"];
 
-	listenHTTP(settings, &handleRequest);
+	auto l = listenHTTP(settings, &handleRequest);
+	scope (exit) l.stopListening();
+
+	runApplication();
 }

--- a/examples/http_static_server/dub.json
+++ b/examples/http_static_server/dub.json
@@ -1,8 +1,0 @@
-﻿{
-	"name": "http-static-server-example",
-	"description": "Simple HTTP server that serves static files.",
-	"dependencies": {
-		"vibe-d:http": {"path": "../../"}
-	},
-	"versions": ["VibeDefaultMain"]
-}

--- a/examples/http_static_server/dub.sdl
+++ b/examples/http_static_server/dub.sdl
@@ -1,0 +1,3 @@
+name "http-static-server-example"
+description "Simple HTTP server that serves static files."
+dependency "vibe-d:http" path="../../"

--- a/examples/http_static_server/source/app.d
+++ b/examples/http_static_server/source/app.d
@@ -1,4 +1,4 @@
-import vibe.appmain;
+import vibe.core.core : runApplication;
 import vibe.http.fileserver;
 import vibe.http.router;
 import vibe.http.server;
@@ -8,7 +8,7 @@ void handleRequest(scope HTTPServerRequest req, scope HTTPServerResponse res)
 	res.redirect("/index.html");
 }
 
-shared static this()
+void main()
 {
 	auto settings = new HTTPServerSettings;
 	settings.port = 8080;
@@ -21,5 +21,8 @@ shared static this()
 	router.get("/gzip/*", serveStaticFiles("./public/", fileServerSettings));
 	router.get("*", serveStaticFiles("./public/",));
 
-	listenHTTP(settings, router);
+	auto l = listenHTTP(settings, router);
+	scope (exit) l.stopListening();
+
+	runApplication();
 }

--- a/examples/https_server/dub.json
+++ b/examples/https_server/dub.json
@@ -1,8 +1,0 @@
-﻿{
-	"name": "https-server-example",
-	"description": "Uses the HTTPS protocol for serving requests.",
-	"dependencies": {
-		"vibe-d:http": {"path": "../../"}
-	},
-	"versions": ["VibeDefaultMain"]
-}

--- a/examples/https_server/dub.sdl
+++ b/examples/https_server/dub.sdl
@@ -1,0 +1,3 @@
+name "https-server-example"
+description "Uses the HTTPS protocol for serving requests."
+dependency "vibe-d:http" path="../../"

--- a/examples/https_server/source/app.d
+++ b/examples/https_server/source/app.d
@@ -1,4 +1,4 @@
-import vibe.appmain;
+import vibe.core.core : runApplication;
 import vibe.http.server;
 import vibe.stream.tls;
 
@@ -7,7 +7,7 @@ void handleRequest(scope HTTPServerRequest req, scope HTTPServerResponse res)
 	res.writeBody(cast(ubyte[])"Hello, World!", "text/plain");
 }
 
-shared static this()
+void main()
 {
 	auto settings = new HTTPServerSettings;
 	settings.port = 8080;
@@ -16,5 +16,8 @@ shared static this()
 	settings.tlsContext.useCertificateChainFile("server.crt");
 	settings.tlsContext.usePrivateKeyFile("server.key");
 
-	listenHTTP(settings, &handleRequest);
+	auto l = listenHTTP(settings, &handleRequest);
+	scope (exit) l.stopListening();
+
+	runApplication();
 }


### PR DESCRIPTION
- Uses a custom main instead of relying on the default implementation
- Stops the HTTP listener on shutdown to avoid socket leak warnings