### PR TITLE
Fix segmentation fault on SSL_read due to null SSLState

### DIFF
--- a/tls/vibe/stream/openssl.d
+++ b/tls/vibe/stream/openssl.d
@@ -338,7 +338,8 @@ final class OpenSSLStream : TLSStream {
 	size_t read(scope ubyte[] dst, IOMode mode)
 	{
 		size_t nbytes = 0;
-		if(m_tls == null) return 0;
+		if(m_tls == null)
+			throw new Exception("Reading from closed stream");
 
 		while (dst.length > 0) {
 			int readlen = min(dst.length, int.max);

--- a/tls/vibe/stream/openssl.d
+++ b/tls/vibe/stream/openssl.d
@@ -316,6 +316,8 @@ final class OpenSSLStream : TLSStream {
 
 	@property ulong leastSize()
 	{
+		if(m_tls == null) return 0;
+
 		auto ret = () @trusted { return SSL_peek(m_tls, m_peekBuffer.ptr, 1); } ();
 		if (ret != 0) // zero means the connection got closed
 			checkSSLRet(ret, "Peeking TLS stream");
@@ -336,6 +338,7 @@ final class OpenSSLStream : TLSStream {
 	size_t read(scope ubyte[] dst, IOMode mode)
 	{
 		size_t nbytes = 0;
+		if(m_tls == null) return 0;
 
 		while (dst.length > 0) {
 			int readlen = min(dst.length, int.max);


### PR DESCRIPTION
While testing the HTTP/2 module there were some cases in which reading from a `OpenSSLStream` failed with a segmentation fault. This is due to the fact that the underlying `SSLState` gets freed when receiving a `close_notify` alert from TLS.

The `SIGSEV` was caused by the usage of a `null` `m_tls` state which would be passed to `SSL_read` and `SSL_peek`, resulting in a memory corruption. An easy fix for this is to add checks for `null` in both `OpenSSLStream.read()` and `OpenSSLStream.leastSize()` and since both methods are supposed to return an integral, return `0` instead.