### PR TITLE
Add stdFile property to StdFileStream

### DIFF
--- a/stream/vibe/stream/stdio.d
+++ b/stream/vibe/stream/stdio.d
@@ -48,6 +48,8 @@ class StdFileStream : ConnectionStream {
 		}
 	}
 
+	@property std.stdio.File stdFile() { return m_file; }
+
 	override @property bool empty() { enforceReadable(); return m_readPipe.empty; }
 
 	override @property ulong leastSize()


### PR DESCRIPTION
Its often useful to get access to the underlying data for interacting with other APIs such as `std.process`.