### PR TITLE
Made WebParamAttribute public to allow rest introspection

### DIFF
--- a/web/vibe/web/common.d
+++ b/web/vibe/web/common.d
@@ -482,14 +482,18 @@ package struct PathAttribute
 /// private
 package struct NoRouteAttribute {}
 
-/// Private struct describing the origin of a parameter (Query, Header, Body).
-package struct WebParamAttribute {
+/**
+ * This struct contains a mapping between the name used by HTTP (field)
+ * and the parameter (identifier) name of the function.
+ */
+public struct WebParamAttribute {
 	import vibe.web.internal.rest.common : ParameterKind;
 
+	/// The type of the WebParamAttribute
 	ParameterKind origin;
-	/// Parameter name
+	/// Parameter name (function parameter name).
 	string identifier;
-	/// The meaning of this field depends on the origin.
+	/// The meaning of this field depends on the origin. (HTTP request name)
 	string field;
 }
 


### PR DESCRIPTION
I'm currently building a angular service generator.
This is done by introspecting rest interfaces.
To get the parameter names right, it needs to look at the UDAs, and more
specifically at WebParamAttribute.