### PR TITLE
Add BsonDate.toSysTime(tz) overload

### DIFF
--- a/data/vibe/data/bson.d
+++ b/data/vibe/data/bson.d
@@ -1054,11 +1054,17 @@ struct BsonDate {
 	*/
 	string toString() const { return toSysTime().toISOExtString(); }
 
-	/* Converts to a SysTime.
+	/* Converts to a SysTime using UTC timezone.
 	*/
 	SysTime toSysTime() const {
+		return toSysTime(UTC());
+	}
+
+	/* Converts to a SysTime with a given timezone.
+	*/
+	SysTime toSysTime(immutable TimeZone tz) const {
 		auto zero = unixTimeToStdTime(0);
-		return SysTime(zero + m_time * 10_000L, UTC());
+		return SysTime(zero + m_time * 10_000L, tz);
 	}
 
 	/** Allows relational and equality comparisons.


### PR DESCRIPTION
Otherwise right now when using the Bson constructor taking a date with null timezone, it will take the local time. When the local time timezone is negative and you want to convert back from BsonDate to SysTime to Date, you will be a day behind than what you originally input because you can only convert to SysTime using UTC.