### PR TITLE
Make PathAttribute public for introspection

### DIFF
--- a/web/vibe/web/common.d
+++ b/web/vibe/web/common.d
@@ -472,9 +472,12 @@ package struct MethodAttribute
 	alias data this;
 }
 
-/// private
-package struct PathAttribute
+/**
+ * This struct contains the name of a route specified by the `path` function.
+ */
+struct PathAttribute
 {
+	/// The specified path
 	string data;
 	alias data this;
 }


### PR DESCRIPTION
To build a function that can call a rest interfaces and provide a JWT,
I needed to introspect on the PathAttribute.