### PR TITLE
Fix bug with sanity check on key length.

### DIFF
--- a/web/vibe/web/common.d
+++ b/web/vibe/web/common.d
@@ -746,7 +746,7 @@ package ParamResult readFormParamRec(T)(scope HTTPServerRequest req, ref T dst, 
 		}
 		// process the items in the order they appear.
 		char indexSep = style == NestedNameStyle.d ? '[' : '_';
-		const minLength = fieldname.length + style == NestedNameStyle.d ? 2 : 1;
+		const minLength = fieldname.length + (style == NestedNameStyle.d ? 2 : 1);
 		const indexTrailer = style == NestedNameStyle.d ? "]" : "";
 
 		ParamResult processItems(DL)(DL dlist)
@@ -951,6 +951,12 @@ unittest {
 	result = req.readFormParamRec(staticarr2, "arr", false, NestedNameStyle.d, err);
 	assert(result == ParamResult.ok);
 	assert(staticarr2 == [[2,4],[3]]);
+
+	// bug with key length
+	req = createTestHTTPServerRequest(URL("http://localhost/route?arr=1"));
+	result = req.readFormParamRec(arr, "arr", false, NestedNameStyle.d, err);
+	assert(result == ParamResult.ok);
+	assert(arr.length == 0);
 }
 
 package bool webConvTo(T)(string str, ref T dst, ref ParamError err)

--- a/web/vibe/web/web.d
+++ b/web/vibe/web/web.d
@@ -142,12 +142,14 @@ import std.encoding : sanitize;
 
 		$(D @before), $(D @after), $(D @errorDisplay),
 		$(D @vibe.web.common.method), $(D @vibe.web.common.path),
-		$(D @vibe.web.common.contentType),
-		$(D @nestedNameStyle)
+		$(D @vibe.web.common.contentType)
 
 		The `@path` attribute can also be applied to the class itself, in which
 		case it will be used as an additional prefix to the one in
 		`WebInterfaceSettings.urlPrefix`.
+
+		The $(D @nestedNameStyle) attribute can be applied only to the class
+		itself. Applying it to a method is not supported at this time.
 
 	Supported return types:
 		$(UL
@@ -728,7 +730,8 @@ unittest {
 	}
 }
 
-/** Determines how nested D fields/array entries are mapped to form field names.
+/** Determines how nested D fields/array entries are mapped to form field
+ * names. Note that this attribute only works if applied to the class.
 */
 NestedNameStyleAttribute nestedNameStyle(NestedNameStyle style)
 {


### PR DESCRIPTION
Issue is with operator precedence, so the `minLength` constant was effectively always 2.

Also update docs to say that `nestedNameStyle` is only supported on the class, and not individual
methods. Seems like an odd limitation, but I'm just documenting what is present in the code currently (found out the hard way). May be something to revisit in the future, but not important at the moment.