### PR TITLE
Fix #1941 - real fix for the workaround

### DIFF
--- a/data/vibe/data/serialization.d
+++ b/data/vibe/data/serialization.d
@@ -1199,11 +1199,15 @@ private template isBuiltinTuple(T, string member)
 }
 
 // heuristically determines @safe'ty of the serializer by testing readValue and writeValue for type int
-private enum isSafeSerializer(S) = __traits(compiles, (S s) @safe {
+private template isSafeSerializer(S)
+{
 	alias T = Traits!(int, DefaultPolicy);
-	s.writeValue!T(42);
-	s.readValue!(T, int)();
-});
+	static if (__traits(hasMember, S, "writeValue"))
+		enum isSafeSerializer = __traits(compiles, (S s) @safe { s.writeValue!T(42); });
+	else static if (__traits(hasMember, S, "readValue"))
+		enum isSafeSerializer = __traits(compiles, (S s) @safe { s.readValue!(T, int)(); });
+	else static assert(0, "Serializer without writeValue or readValue is invalid");
+}
 
 private template hasAttribute(T, alias decl) { enum hasAttribute = findFirstUDA!(T, decl).found; }
 

--- a/data/vibe/data/serialization.d
+++ b/data/vibe/data/serialization.d
@@ -572,7 +572,7 @@ private template deserializeValueImpl(Serializer, alias Policy) {
 	static assert(Serializer.isSupportedValueType!(typeof(null)), "All serializers must support null values.");
 
 	// work around https://issues.dlang.org/show_bug.cgi?id=16528
-	static if (isSafeSerializer!Serializer) {
+	static if (isSafeDeserializer!Serializer) {
 		T deserializeValue(T, ATTRIBUTES...)(ref Serializer ser) @safe { return deserializeValueDeduced!(T, ATTRIBUTES)(ser); }
 	} else {
 		T deserializeValue(T, ATTRIBUTES...)(ref Serializer ser) { return deserializeValueDeduced!(T, ATTRIBUTES)(ser); }
@@ -1204,9 +1204,16 @@ private template isSafeSerializer(S)
 	alias T = Traits!(int, DefaultPolicy);
 	static if (__traits(hasMember, S, "writeValue"))
 		enum isSafeSerializer = __traits(compiles, (S s) @safe { s.writeValue!T(42); });
-	else static if (__traits(hasMember, S, "readValue"))
-		enum isSafeSerializer = __traits(compiles, (S s) @safe { s.readValue!(T, int)(); });
-	else static assert(0, "Serializer without writeValue or readValue is invalid");
+	else static assert(0, "Serializer is missing required writeValue method");
+}
+
+// heuristically determines @safe'ty of the deserializer by testing readValue and writeValue for type int
+private template isSafeDeserializer(S)
+{
+	alias T = Traits!(int, DefaultPolicy);
+	static if (__traits(hasMember, S, "readValue"))
+		enum isSafeDeserializer = __traits(compiles, (S s) @safe { s.readValue!(T, int)(); });
+	else static assert(0, "Deserializer is missing required readValue method");
 }
 
 private template hasAttribute(T, alias decl) { enum hasAttribute = findFirstUDA!(T, decl).found; }
@@ -1344,6 +1351,7 @@ private template getExpandedFieldsData(T, FIELDS...)
 
 version (unittest) {
 	static assert(isSafeSerializer!TestSerializer);
+	static assert(isSafeDeserializer!TestSerializer);
 
 	private struct TestSerializer {
 		import std.array, std.conv, std.string;


### PR DESCRIPTION
This bothered me so long that I've finally looked into it and found the issue. :)

Problem was that test for `isSafeSerializer` is using `writeValue` and `readValue` for checking and to pass correctly it requires both to compile.
In unittests, `TestSerializer` is used and works both as a serializer and a deserializer, so the test passes ok.
But that is not the case for ie `JsonStringSerializer` which has only one of those based on the provided range type.
