### PR TITLE
Ddoc warning fix

### DIFF
--- a/data/vibe/data/json.d
+++ b/data/vibe/data/json.d
@@ -2143,6 +2143,8 @@ unittest
 	Params:
 		dst   = References the string output range to which the result is written.
 		json  = Specifies the JSON value that is to be stringified.
+		level = Specifies the base amount of indentation for the output. Indentation is always
+				done using tab characters.
 
 	See_Also: Json.toString, writePrettyJsonString
 */


### PR DESCRIPTION
```
json.d(2149,6): Warning: Ddoc: parameter count mismatch, expected 3, got 2
```

How it passed CI?!