### PR TITLE
Ignore rdmd failures in the OpenSSL version detection.

### DIFF
--- a/tls/dub.sdl
+++ b/tls/dub.sdl
@@ -42,7 +42,7 @@ configuration "openssl" {
 	auto output = dir.buildPath("openssl_version.d");
 	if (!output.exists || output.readText.strip != data.strip)
 		data.toFile(output);
-	'` platform="posix"
+	' || true` platform="posix"
 }
 
 configuration "openssl-1.1" {

--- a/tls/vibe/stream/openssl.d
+++ b/tls/vibe/stream/openssl.d
@@ -49,7 +49,7 @@ else
 {
 	// Only use the openssl_version file if it has been generated
 	static if (__traits(compiles, {import openssl_version; }))
-		mixin("import openssl_version;");
+		mixin("public import openssl_version : OPENSSL_VERSION;");
 	else
 		// try 1.1.0 as softfallback if old other means failed
 		enum OPENSSL_VERSION = "1.1.0";


### PR DESCRIPTION
rdmd fails intermittently with a temporary D module not being found in the temp directory. To avoid spurious CI failures and to allow the code to work on systems where rdmd is not configured correctly, these failures are now ignored and the default version is assumed.