### PR TITLE
New support for parsing cookies

### DIFF
--- a/http/vibe/http/client.d
+++ b/http/vibe/http/client.d
@@ -917,9 +917,9 @@ final class HTTPClientResponse : HTTPResponse {
 
 
 	/// All cookies that shall be set on the client for this request
-	override @property DictionaryList!Cookie cookies() {
+	override @property ref DictionaryList!Cookie cookies() {
 		if ("Set-Cookie" in this.headers && m_cookies.length == 0) {
-			foreach(cookieString; this.headers.getAll("Set-Cookie")) {
+			foreach (cookieString; this.headers.getAll("Set-Cookie")) {
 				auto cookie = parseHTTPCookie(cookieString);
 				if (cookie[0].length)
 					m_cookies[cookie[0]] = cookie[1];

--- a/http/vibe/http/client.d
+++ b/http/vibe/http/client.d
@@ -921,7 +921,8 @@ final class HTTPClientResponse : HTTPResponse {
 		if ("Set-Cookie" in this.headers && m_cookies.length == 0) {
 			foreach(cookieString; this.headers.getAll("Set-Cookie")) {
 				auto cookie = parseHTTPCookie(cookieString);
-				m_cookies[cookie[0]] = cookie[1];
+				if (cookie[0].length)
+					m_cookies[cookie[0]] = cookie[1];
 			}
 		}
 		return m_cookies;

--- a/http/vibe/http/client.d
+++ b/http/vibe/http/client.d
@@ -23,6 +23,7 @@ import vibe.stream.operations;
 import vibe.stream.wrapper : createConnectionProxyStream;
 import vibe.stream.zlib;
 import vibe.utils.array;
+import vibe.utils.dictionarylist;
 import vibe.internal.allocator;
 import vibe.internal.freelistref;
 import vibe.internal.interfaceproxy : InterfaceProxy, interfaceProxy;
@@ -914,6 +915,18 @@ final class HTTPClientResponse : HTTPResponse {
 		return m_maxRequests;
 	}
 
+
+	/// All cookies that shall be set on the client for this request
+	override @property DictionaryList!Cookie cookies() {
+		if ("Set-Cookie" in this.headers && m_cookies.length == 0) {
+			foreach(cookieString; this.headers.getAll("Set-Cookie")) {
+				auto cookie = parseHTTPCookie(cookieString);
+				m_cookies[cookie[0]] = cookie[1];
+			}
+		}
+		return m_cookies;
+	}
+
 	/// private
 	this(HTTPClient client, bool has_body, bool close_conn, IAllocator alloc, SysTime connected_time = Clock.currTime(UTC()))
 	{
@@ -947,7 +960,6 @@ final class HTTPClientResponse : HTTPResponse {
 		foreach (k, v; this.headers)
 			logTrace("%s: %s", k, v);
 		logTrace("---------------------");
-
 		Duration server_timeout;
 		bool has_server_timeout;
 		if (auto pka = "Keep-Alive" in this.headers) {

--- a/tests/vibe.http.client.2025/dub.json
+++ b/tests/vibe.http.client.2025/dub.json
@@ -1,0 +1,6 @@
+{
+	"name": "2025",
+	"dependencies": {
+		"vibe-d:http": { "path": "../../" }
+	}
+}

--- a/tests/vibe.http.client.2025/source/app.d
+++ b/tests/vibe.http.client.2025/source/app.d
@@ -1,0 +1,43 @@
+/++ dub.sdl:
+	dependency "vibe-d" path=".."
++/
+import vibe.core.core;
+import vibe.http.client;
+import vibe.http.server;
+import vibe.core.log;
+
+void main()
+{
+	auto settings = new HTTPServerSettings;
+	settings.port = 0;
+	settings.bindAddresses = ["127.0.0.1"];
+	auto l = listenHTTP(settings, (req, res) {
+		res.headers.addField("Set-Cookie", "hello=world; Path=/path");
+		// res.setCookie("hello", "world", "/path");
+		res.writeBody("Hello, World!");
+	});
+
+	auto url = URL("http", "127.0.0.1", l.bindAddresses[0].port, InetPath("/"));
+
+	runTask({
+		try {
+			auto res = requestHTTP(url);
+			assert(res.statusCode == 200, res.toString);
+
+			assert(res.cookies.length == 1);
+			auto cookie = res.cookies.get("hello");
+			assert(cookie !is null);
+			assert(cookie.value == "world");
+			assert(cookie.httpOnly == false);
+			assert(cookie.secure == false);
+			assert(cookie.expires == "");
+			assert(cookie.maxAge == 0);
+			assert(cookie.domain == "");
+			assert(cookie.path == "/path");
+
+			res.dropBody();
+			exitEventLoop();
+		} catch (Exception e) assert(false, e.msg);
+	});
+	runApplication();
+}


### PR DESCRIPTION
Continuation of #2025 because I didn't have push permissions

Changes:
- algorithm implemented like specified on RFC
    - ignore invalid values
    - discard cookie in some cases
    - normalization of some values (e.g. Domain)
- high level test

For the high level test I manually wrote the header on the server as setCookie didn't seem to work