### PR TITLE
consider 304 Not Modified as a success code

### DIFF
--- a/http/vibe/http/status.d
+++ b/http/vibe/http/status.d
@@ -185,10 +185,10 @@ bool justifiesConnectionClose(int status)
 }
 
 /**
-	Determines if status code is generally successful (>= 200 && < 300)
+	Determines if status code is generally successful ((>= 200 && < 300) || 304)
 */
 bool isSuccessCode(HTTPStatus status)
 {
-	return status >= 200 && status < 300;
+	return (status >= 200 && status < 300) || status == 304;
 }
 


### PR DESCRIPTION
We use a proxy mechanism in our API and have log full of exceptions due to 304 Not Modified handled as error code.

Of 3xx codes this one should probably be handled as a success call?