### PR TITLE
hashmap: increase hashing speed with integer or string keys

### DIFF
--- a/utils/vibe/utils/hashmap.d
+++ b/utils/vibe/utils/hashmap.d
@@ -28,6 +28,10 @@ struct DefaultHashMapTraits(Key) {
 			return () @trusted { return (cast(Key)k).toHash(); } ();
 		else static if (__traits(compiles, Key.init.toHashShared()))
 			return k.toHashShared();
+		else static if ((__traits(isScalar, Key) ||
+				(isArray!Key && is(Key : E[], E) && __traits(isScalar, E))) &&
+				is(typeof((in Key x) @nogc nothrow pure @safe => .object.hashOf(x))))
+			return .object.hashOf(k);
 		else {
 			// evil casts to be able to get the most basic operations of
 			// HashMap nothrow and @nogc


### PR DESCRIPTION
`TypeInfo.getHash` is a virtual function call that is opaque to current D compilers. Directly using `object.hashOf` is faster.