### PR TITLE
implement more caching & public cache api

### DIFF
--- a/web/vibe/web/rest.d
+++ b/web/vibe/web/rest.d
@@ -470,17 +470,13 @@ HTTPServerRequestDelegate serveRestJSClient(I)(RestInterfaceSettings settings)
 	if (is(I == interface))
 {
 	import std.datetime.systime : SysTime;
-	import std.digest.md : md5Of;
-	import std.digest : toHexString;
 	import std.array : appender;
 
 	import vibe.http.fileserver : ETag, handleCache;
 
 	auto app = appender!string();
 	generateRestJSClient!I(app, settings);
-	auto hash = app.data.md5Of.toHexString.idup;
-	ETag tag;
-	tag.tag = hash;
+	ETag tag = ETag.md5(false, app.data);
 
 	void serve(HTTPServerRequest req, HTTPServerResponse res)
 	{

--- a/web/vibe/web/rest.d
+++ b/web/vibe/web/rest.d
@@ -244,7 +244,7 @@ import vibe.web.auth : AuthInfo, handleAuthentication, handleAuthorization, isAu
 
 import std.algorithm : startsWith, endsWith;
 import std.range : isOutputRange;
-import std.typecons : Nullable;
+import std.typecons : No, Nullable, Yes;
 import std.typetuple : anySatisfy, Filter;
 import std.traits;
 
@@ -476,7 +476,7 @@ HTTPServerRequestDelegate serveRestJSClient(I)(RestInterfaceSettings settings)
 
 	auto app = appender!string();
 	generateRestJSClient!I(app, settings);
-	ETag tag = ETag.md5(false, app.data);
+	ETag tag = ETag.md5(No.weak, app.data);
 
 	void serve(HTTPServerRequest req, HTTPServerResponse res)
 	{


### PR DESCRIPTION
Allows to have runtime generated bodies with proper cache

For example you can cache runtime diet files with this: (with my runtime diet PR on diet-ng)

```d
import diet.html;

if (handleCacheFile(req, res, "templates/client.dt", "public"))
	return;

res.writeBody(renderStaticHTMLDietFile("templates/client.dt"), "text/html; charset=UTF-8");
```