### PR TITLE
Add way to disable port and address reuse

### DIFF
--- a/core/dub.sdl
+++ b/core/dub.sdl
@@ -13,7 +13,7 @@ mainSourceFile "vibe/appmain.d"
 
 configuration "vibe-core" {
 	targetType "none"
-	dependency "vibe-core" version=">=1.6.3-alpha.1 <2.0.0-0"
+	dependency "vibe-core" version=">=1.6.3-alpha.2 <2.0.0-0"
 }
 
 configuration "win32_mscoff" {

--- a/core/vibe/core/net.d
+++ b/core/vibe/core/net.d
@@ -455,7 +455,7 @@ interface UDPConnection {
 */
 enum TCPListenOptions {
 	/// Don't enable any particular option
-	defaults = 0,
+	none = 0,
 	/// Causes incoming connections to be distributed across the thread pool
 	distribute = 1<<0,
 	/// Disables automatic closing of the connection when the connection callback exits
@@ -466,7 +466,7 @@ enum TCPListenOptions {
 	reusePort = 1<<2,
 	/// Enable address reuse
 	reuseAddress = 1<<3,
-	///
+	/// Enables address reuse by default
 	defaults = reuseAddress
 }
 

--- a/core/vibe/core/net.d
+++ b/core/vibe/core/net.d
@@ -464,6 +464,10 @@ enum TCPListenOptions {
 	    Does not affect libasync driver because it is always enabled by libasync.
 	*/
 	reusePort = 1<<2,
+	/// Enable address reuse
+	reuseAddress = 1<<3,
+	///
+	defaults = reuseAddress
 }
 
 private pure nothrow {


### PR DESCRIPTION
This integrates with recent event core `reuseAddress` flag.
It allows one to selectively disable those flags.
See https://github.com/vibe-d/vibe-core/pull/150