### PR TITLE
Fix: #2279 - MacOS std.json.JSONException@std/json.d(155): JSONValue …

### DIFF
--- a/setup-mac.sh
+++ b/setup-mac.sh
@@ -26,8 +26,8 @@ USER_ID=$(dscl . -read /Users/_www UniqueID | sed "s/[^:]*: //")
 GROUP_ID=$(dscl . -read /Groups/_www PrimaryGroupID | sed "s/[^:]*: //")
 mkdir -p $(dirname $CONFIG_FILE)
 echo -e '{
-	"uid": '$USER_ID',
-	"gid": '$GROUP_ID'
+	"uid": "'$USER_ID'",
+	"gid": "'$GROUP_ID'"
 }' >$CONFIG_FILE
 
 # if everything went fine


### PR DESCRIPTION
…is not a string

Reference:
https://github.com/vibe-d/vibe-core/issues/146
https://github.com/vibe-d/vibe-core/pull/149