### PR TITLE
Fix parsing of IPv6 Addresses in vibe.inet.url

### DIFF
--- a/inet/vibe/inet/url.d
+++ b/inet/vibe/inet/url.d
@@ -116,7 +116,12 @@ struct URL {
 		auto str = url_string;
 		enforce(str.length > 0, "Empty URL.");
 		if( str[0] != '/' ){
-			auto idx = str.indexOfCT(':');
+			size_t idx;
+			if (str[0] == '[') {
+				idx = str.indexOfCT(']') + 1;
+			} else {
+				idx = str.indexOfCT(':');
+			}
 			enforce(idx > 0, "No schema in URL:"~str);
 			m_schema = str[0 .. idx];
 			str = str[idx+1 .. $];

--- a/inet/vibe/inet/url.d
+++ b/inet/vibe/inet/url.d
@@ -17,6 +17,7 @@ import std.conv;
 import std.exception;
 import std.string;
 import std.traits : isInstanceOf;
+import std.ascii : isAlpha;
 
 
 /**
@@ -119,6 +120,9 @@ struct URL {
 			auto idx = str.indexOf(':');
 			enforce(idx > 0, "No schema in URL:"~str);
 			m_schema = str[0 .. idx];
+			enforce(m_schema[0].isAlpha,
+					"Schema must start with an alphabetical char, found: " ~
+					m_schema[0]);
 			str = str[idx+1 .. $];
 			bool requires_host = false;
 


### PR DESCRIPTION
The current implementation of `URL.parse` fails when provided with an IPv6 Address. Using the latest master branch:
```D
import vibe.inet.url;

void main()
{
	auto url = URL.parse("localhost:8080");
	auto ipv6url = URL.parse("[1080:0:0:0:8:800:200C:417A]:8888");
}
```
The program gives the following result:
```
std.conv.ConvException@/opt/dmd-2.085/import/std/conv.d(1865): Unexpected ':' when converting from type string to type ushort
```
The code responsible for this is in `url.d` when the parser looks for  the index of the first `:` occurrence. The presence of `:` inside IPv6 addresses is not taken into account, causing a failure when trying to convert the expected port to `ushort`.

The proposed fix consider both cases by setting the index accordingly.

Edit: this can also be seen here: [https://run.dlang.io/is/SxRV9e](https://run.dlang.io/is/SxRV9e)