### PR TITLE
Make unix socket support work for vibe-core

### DIFF
--- a/http/vibe/http/client.d
+++ b/http/vibe/http/client.d
@@ -42,10 +42,7 @@ import std.socket : AddressFamily;
 
 version(Posix)
 {
-	version(VibeLibeventDriver)
-	{
-		version = UnixSocket;
-	}
+	version = UnixSocket;
 }
 
 


### PR DESCRIPTION
In relation to #500, unix sockets are supported by vibe-core, not just Libevent, so I suggest we make that work out of the box. My current workaround is to put `UnixSocket` in a build.