### PR TITLE
Fix wss/ws websocket connection fix #2320

### DIFF
--- a/http/vibe/http/websockets.d
+++ b/http/vibe/http/websockets.d
@@ -85,6 +85,9 @@ class WebSocketException: Exception
 */
 WebSocket connectWebSocket(URL url, const(HTTPClientSettings) settings = defaultSettings)
 @safe {
+	const use_tls = (url.schema == "wss" || url.schema == "https") ? true : false;
+	url.schema = use_tls ? "https" : "http";
+
 	auto rng = secureRNG();
 	auto challengeKey = generateChallengeKey(rng);
 	auto answerKey = computeAcceptKey(challengeKey);
@@ -108,7 +111,7 @@ WebSocket connectWebSocket(URL url, const(HTTPClientSettings) settings = default
 /// ditto
 void connectWebSocket(URL url, scope WebSocketHandshakeDelegate del, const(HTTPClientSettings) settings = defaultSettings)
 @safe {
-	bool use_tls = (url.schema == "wss") ? true : false;
+	const use_tls = (url.schema == "wss" || url.schema == "https") ? true : false;
 	url.schema = use_tls ? "https" : "http";
 
 	/*scope*/auto rng = secureRNG();

--- a/tests/vibe.http.websocket.2169/source/app.d
+++ b/tests/vibe.http.websocket.2169/source/app.d
@@ -25,7 +25,7 @@ void test(bool tls)
 	}));
 
 	const serverAddr = listener.bindAddresses[0];
-	const server_url = URL((tls ? "https://" : "http://") ~ serverAddr.toString);
+	const server_url = URL((tls ? "wss://" : "ws://") ~ serverAddr.toString);
 
 	runTask({
 		scope(exit) exitEventLoop(true);


### PR DESCRIPTION
connectWebSocket now supports both wss/ws and https/http
the connectWebSocket example is fixed by this and existing usage should work again