### PR TITLE
Add createIndex, getIndexes and improve docstrings

### DIFF
--- a/mongodb/vibe/db/mongo/collection.d
+++ b/mongodb/vibe/db/mongo/collection.d
@@ -469,6 +469,7 @@ struct MongoCollection {
 		if (flags & IndexFlags.expireAfterSeconds) doc["expireAfterSeconds"] = expire_time.total!"seconds";
 		database["system.indexes"].insert(doc);
 	}
+
 	/// ditto
 	deprecated("Use the overload taking an array of field_orders instead.")
 	void ensureIndex(int[string] field_orders, IndexFlags flags = IndexFlags.none, ulong expireAfterSeconds = 0)
@@ -479,6 +480,9 @@ struct MongoCollection {
 		ensureIndex(orders, flags, expireAfterSeconds.seconds);
 	}
 
+	/**
+		Drops or removes the specified index from the collection.
+	*/
 	void dropIndex(string name)
 	@safe {
 		static struct CMD {
@@ -493,6 +497,45 @@ struct MongoCollection {
 		enforce(reply["ok"].get!double == 1, "dropIndex command failed: "~reply["errmsg"].opt!string);
 	}
 
+	/**
+		Creates indexes on the collection.
+	*/
+	void createIndex(T)(T query) 
+	@safe {
+		static struct Indexes {
+			T key;
+		}
+
+		static struct CMD {
+			string createIndexes;
+			Indexes indexes;
+		}
+
+		CMD cmd;
+		cmd.createIndexes = m_name;
+		cmd.indexes.key = query;
+		auto reply = database.runCommand(cmd);
+		enforce(reply["ok"].get!double == 1, "createIndex command failed: "~reply["errmsg"].opt!string);
+	}
+
+	/**
+		Returns an array that holds a list of documents that identify and describe the existing indexes on the collection. 
+	*/
+	R getIndexes(T = Bson, R = Bson)() {
+		static struct CMD {
+			string listIndexes;
+		}
+
+		CMD cmd;
+		listIndexes = m_name;
+
+		auto reply = database.runCommand(cmd);
+		return reply;
+	}
+
+	/**
+		Removes a collection or view from the database. The method also removes any indexes associated with the dropped collection.
+	*/
 	void drop()
 	@safe {
 		static struct CMD {

--- a/mongodb/vibe/db/mongo/collection.d
+++ b/mongodb/vibe/db/mongo/collection.d
@@ -521,17 +521,18 @@ struct MongoCollection {
 	/**
 		Returns an array that holds a list of documents that identify and describe the existing indexes on the collection. 
 	*/
-	R getIndexes(T = Bson, R = Bson)() 
+	MongoCursor!R getIndexes(T = Bson, R = Bson)() 
 	@safe {
 		static struct CMD {
 			string listIndexes;
 		}
 
 		CMD cmd;
-		listIndexes = m_name;
+		cmd.listIndexes = m_name;
 
 		auto reply = database.runCommand(cmd);
-		return reply;
+		enforce(reply["ok"].get!double == 1, "getIndexes command failed: "~reply["errmsg"].opt!string);
+		return MongoCursor!R(m_client, reply["cursor"]["ns"].get!string, reply["cursor"]["id"].get!long, reply["cursor"]["firstBatch"].get!(Bson[]));
 	}
 
 	/**

--- a/mongodb/vibe/db/mongo/collection.d
+++ b/mongodb/vibe/db/mongo/collection.d
@@ -521,7 +521,8 @@ struct MongoCollection {
 	/**
 		Returns an array that holds a list of documents that identify and describe the existing indexes on the collection. 
 	*/
-	R getIndexes(T = Bson, R = Bson)() {
+	R getIndexes(T = Bson, R = Bson)() 
+	@safe {
 		static struct CMD {
 			string listIndexes;
 		}


### PR DESCRIPTION
This PR adds createIndex, getIndex and improves some of the index related documentation strings.

The strings are taken (and slightly modified) info from the mongodb documentation.

This is a part of the way to getting https://github.com/vibe-d/vibe.d/issues/2200 done