### PR TITLE
Free libevent TCP resources on finalize() and GC finalization.

### DIFF
--- a/core/vibe/core/drivers/libevent2_tcp.d
+++ b/core/vibe/core/drivers/libevent2_tcp.d
@@ -101,10 +101,13 @@ package final class Libevent2TCPConnection : TCPConnection {
 		} ();
 	}
 
-	/*~this()
-	{
-		//assert(m_ctx is null, "Leaking TCPContext because it has not been cleaned up and we are not allowed to touch the GC in finalizers..");
-	}*/
+	~this()
+	@trusted {
+		if (m_ctx && m_ctx.state == ConnectionState.passiveClose) {
+			if (m_ctx.event) bufferevent_free(m_ctx.event);
+			TCPContextAlloc.free(m_ctx);
+		}
+	}
 
 	@property void tcpNoDelay(bool enabled)
 	{
@@ -389,6 +392,14 @@ package final class Libevent2TCPConnection : TCPConnection {
 	void finalize()
 	{
 		flush();
+
+		if (m_ctx && m_ctx.state == ConnectionState.passiveClose) {
+			() @trusted {
+				if (m_ctx.event) bufferevent_free(m_ctx.event);
+				TCPContextAlloc.free(m_ctx);
+			} ();
+			m_ctx = null;
+		}
 	}
 
 	private bool fillReadBuffer(bool block, bool throw_on_fail = true, bool wait_for_timeout = false)


### PR DESCRIPTION
Closes #1324 of which this is more or less a rebased version.

Supposedly fixes #1321 when using libevent.