### PR TITLE
Don't use chunked transfer with HTTP/1.0

### DIFF
--- a/http/vibe/http/client.d
+++ b/http/vibe/http/client.d
@@ -749,7 +749,6 @@ final class HTTPClientRequest : HTTPRequest {
 	/// ditto
 	void writeBody(InputStream data)
 	{
-		headers["Transfer-Encoding"] = "chunked";
 		data.pipe(bodyWriter);
 		finalize();
 	}
@@ -834,7 +833,8 @@ final class HTTPClientRequest : HTTPRequest {
 
 		assert(!m_headerWritten, "Trying to write request body after body was already written.");
 
-		if ("Content-Length" !in headers && "Transfer-Encoding" !in headers
+		if (httpVersion != HTTPVersion.HTTP_1_0
+			&& "Content-Length" !in headers && "Transfer-Encoding" !in headers
 			&& headers.get("Connection", "") != "close")
 		{
 			headers["Transfer-Encoding"] = "chunked";


### PR DESCRIPTION
We've needed to communicate with some Axis device which listens using HTTP/1.0 and so don't know about chunked transfer.

From the specs:

> **Content-Length:** <Ignored if ommitted or zero, or shall be set to transfer length of message body.>
> 
> When an audio stream is transmitted, the server receives a continuous flow of audio packets. The content type is only set at the beginning of the connection together with the content length that can have any value. When the connection is up and running the audio packets will come right after another without any extra information between the packets. The message body contains a block of binary data.
>
> The content length must be set to a valid size and will generate a server response for every successful playback. If the playback fails, the connection will be closed without any response.

As we're sending live stream there, there is no way to use `Content-Length` and so device's server just closes the connection after some time when no more data are written to it.

This fixes the invalid use of chunked stream in this case and avoids glitches in stream received by the device.