### PR TITLE
unlock ConnectionPool on failure

### DIFF
--- a/core/vibe/core/connectionpool.d
+++ b/core/vibe/core/connectionpool.d
@@ -76,6 +76,8 @@ class ConnectionPool(Connection)
 		debug assert(m_thread is () @trusted { return Thread.getThis(); } (), "ConnectionPool was called from a foreign thread!");
 
 		m_sem.lock();
+		scope (failure) m_sem.unlock();
+
 		size_t cidx = size_t.max;
 		foreach( i, c; m_connections ){
 			auto plc = c in m_lockCount;


### PR DESCRIPTION
I've found that when the connectionFactory method throws, `ConnectionPool` keeps the lock.
My problem was with [dpq2](https://github.com/denizzzka/dpq2/blob/master/src/dpq2/connection.d#L59) postgresql connection that can throw ie when it fails to connect to the server.

I'll create PR also to vibe-core.