### PR TITLE
Close TCPConnection on failure

### DIFF
--- a/http/vibe/http/client.d
+++ b/http/vibe/http/client.d
@@ -569,7 +569,8 @@ final class HTTPClient {
 	{
 		assert(!m_requesting, "Interleaved HTTP client requests detected!");
 		assert(!m_responding, "Interleaved HTTP client request/response detected!");
-
+		scope(failure) disconnect;
+		
 		m_requesting = true;
 		scope(exit) m_requesting = false;
 


### PR DESCRIPTION
I'm not sure if this is the best fix, but it looks like the TCPConnection state is connected after it fails to connect here: `m_conn = connectTCP(proxyAddr, m_settings.networkInterface);`