### PR TITLE
Fixes a const violation where atomicLoad erases const from the return value

### DIFF
--- a/crypto/vibe/crypto/cryptorand.d
+++ b/crypto/vibe/crypto/cryptorand.d
@@ -167,7 +167,7 @@ final class SystemRNG : RandomNumberStream {
 			version (linux) static if (LinuxMaybeHasGetrandom)
 			{
 				import core.atomic : atomicLoad, atomicStore;
-				auto p = atomicLoad(*cast(const shared GET_RANDOM*) &hasGetRandom);
+				GET_RANDOM p = atomicLoad(*cast(const shared GET_RANDOM*) &hasGetRandom);
 				if (p == GET_RANDOM.UNINITIALIZED)
 				{
 					p = initHasGetRandom() ? GET_RANDOM.AVAILABLE


### PR DESCRIPTION
Fix #2348 