### PR TITLE
HTTPServer - add support for HTTP informational status message sending

### DIFF
--- a/http/vibe/http/status.d
+++ b/http/vibe/http/status.d
@@ -54,6 +54,7 @@ enum HTTPStatus {
 	gatewayTimeout               = 504,
 	httpVersionNotSupported      = 505,
 	// WebDAV status codes
+	processing                   = 102, /// See: https://tools.ietf.org/html/rfc2518#section-10.1
 	multiStatus                  = 207,
 	unprocessableEntity          = 422,
 	locked                       = 423,
@@ -160,6 +161,7 @@ string httpStatusText(int code)
 		case HTTPStatus.locked                       : return "Locked";
 		case HTTPStatus.failedDependency             : return "Failed Dependency";
 		case HTTPStatus.insufficientStorage          : return "Insufficient Storage";
+		case HTTPStatus.processing                   : return "Processing";
 	}
 	if( code >= 600 ) return "Unknown";
 	if( code >= 500 ) return "Unknown server error";

--- a/tests/vibe.http.server.informational-status/dub.sdl
+++ b/tests/vibe.http.server.informational-status/dub.sdl
@@ -1,0 +1,3 @@
+name "tests"
+description "informational status response handling test"
+dependency "vibe-d:http" path="../../"

--- a/tests/vibe.http.server.informational-status/source/app.d
+++ b/tests/vibe.http.server.informational-status/source/app.d
@@ -1,0 +1,49 @@
+import core.time;
+import vibe.core.log;
+import vibe.core.core : exitEventLoop, runApplication, runTask, sleep;
+import vibe.http.client;
+import vibe.http.server;
+import vibe.stream.operations : readAllUTF8;
+
+void handleRequest(scope HTTPServerRequest req, scope HTTPServerResponse res)
+{
+	res.statusCode = HTTPStatus.processing;
+	res.writeVoidBody();
+
+	sleep(100.msecs);
+	res.statusCode = HTTPStatus.ok;
+	res.writeBody("Hello, World!", "text/plain");
+}
+
+void main()
+{
+	auto settings = new HTTPServerSettings;
+	settings.port = 8099;
+	settings.bindAddresses = ["::1", "127.0.0.1"];
+
+	auto l = listenHTTP(settings, &handleRequest);
+	scope (exit) l.stopListening();
+
+	runTask({
+		bool got102, got200;
+		scope (exit) exitEventLoop();
+
+		requestHTTP("http://127.0.0.1:8099/", null,
+			(scope res) {
+				if (res.statusCode == HTTPStatus.processing) {
+					assert(!got200, "Status 200 received first");
+					got102 = true;
+				}
+				else if (res.statusCode == HTTPStatus.ok) {
+					got200 = true;
+					assert(res.bodyReader.readAllUTF8() == "Hello, World!");
+				}
+			}
+		);
+		assert(got102, "Status 102 wasn't received");
+		assert(got200, "Status 200 wasn't received");
+		logInfo("All web tests succeeded.");
+	});
+
+	runApplication();
+}


### PR DESCRIPTION
This adds possibility to send HTTP status messages (1xx) using `writeVoidBody` in `HTTPServerResponse`.
I've modified also the client that now can receive these messages in it's `responder` handler prior the final response.

What's not handled properly is `100 Continue` as client just sends the body right away.
I'm not so sure how to fix that as `requester` should begin to write body after `100 Continue` is received from the server in `responder`. Maybe using semaphore between `requester` and `responder`?

But this can probably be handled separately as this PR doesn't change the current behavior for that.