### PR TITLE
make parseRFC5322Header more tolerant on input

### DIFF
--- a/inet/vibe/inet/message.d
+++ b/inet/vibe/inet/message.d
@@ -49,7 +49,8 @@ void parseRFC5322Header(InputStream)(InputStream input, ref InetHeaderMap dst, s
 	}
 
 	string readStringLine() @safe {
-		auto ret = input.readLine(max_line_length, "\r\n", alloc);
+		auto ret = input.readLine(max_line_length, "\n", alloc);
+		if (ret.length && ret[$-1] == '\r') ret = ret[0..$-1];
 		return () @trusted { return cast(string)ret; } ();
 	}
 
@@ -89,6 +90,17 @@ unittest { // fail for empty header names
 	assertThrown(parseRFC5322Header(createMemoryStream(hdr), map));
 }
 
+unittest { // tolerant line separator header parser - see: https://www.w3.org/Protocols/rfc2616/rfc2616-sec19.html#sec19.3
+	import std.exception;
+	import vibe.stream.memory;
+	auto hdr = cast(ubyte[])"a: test\r\nb: foo\nc: bar\n\nbody".dup;
+	InetHeaderMap map;
+	parseRFC5322Header(createMemoryStream(hdr), map);
+	assert(map.length == 3);
+	assert(map["a"] == "test");
+	assert(map["b"] == "foo");
+	assert(map["c"] == "bar");
+}
 
 private immutable monthStrings = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"];
 


### PR DESCRIPTION
This makes HTTP header parser more tolerant to invalid inputs in regards to line separators.

> The line terminator for message-header fields is the sequence CRLF. However, we recommend that applications, when parsing such headers, recognize a single LF as a line terminator and ignore the leading CR. 

See https://www.w3.org/Protocols/rfc2616/rfc2616-sec19.html#sec19.3 for more details.

My problem is again Axis device with some CGI scripts returning something like:

```
HTTP/1.1 200 OK<CR><LF>
Date: Fri, 30 Aug 2019 15:59:02 GMT<CR><LF>
Accept-Ranges: bytes<CR><LF>
Connection: close<CR><LF>
Content-type: text/plain<LF><LF>

<body>
```

Which fails with strict parser.