### PR TITLE
Make sure connection is closed after websocket reader exits

### DIFF
--- a/http/vibe/http/websockets.d
+++ b/http/vibe/http/websockets.d
@@ -778,7 +778,10 @@ final class WebSocket {
 	private void startReader()
 	{
 		m_readMutex.performLocked!({}); //Wait until initialization
-		scope (exit) m_readCondition.notifyAll();
+		scope (exit) {
+			m_conn.close();
+			m_readCondition.notifyAll();
+		}
 		try {
 			while (!m_conn.empty) {
 				assert(!m_nextMessage);


### PR DESCRIPTION
If a `return` or `throw` is triggered in `startReader` it's possible for the connection to stay open after the `scope(exit)` call. This could mean that `waitForData` never returns.