### PR TITLE
Allow cleanup of redis sockets to prevent event core leaking.

### DIFF
--- a/redis/vibe/db/redis/redis.d
+++ b/redis/vibe/db/redis/redis.d
@@ -130,6 +130,16 @@ final class RedisClient {
 		});
 	}
 
+	/** Release all connections that are not in use. Call before exiting the
+	 * program to avoid relying on the GC to clean up the sockets.
+	 */
+	void releaseUnusedConnections() @safe
+	{
+		m_connections.removeUnused((conn) @safe {
+                 conn.m_conn.close();
+		});
+	}
+
 	/// Returns Redis version
 	@property string redisVersion()
 	{

--- a/redis/vibe/db/redis/redis.d
+++ b/redis/vibe/db/redis/redis.d
@@ -135,8 +135,12 @@ final class RedisClient {
 	 */
 	void releaseUnusedConnections() @safe
 	{
-		m_connections.removeUnused((conn) @safe {
+		// the try/catch in this is for the old vibe.d:core library, not
+		// necessary in vibe-core, but we have to work with both.
+		m_connections.removeUnused((conn) @safe nothrow {
+			try {
                  conn.m_conn.close();
+			 } catch(Exception e) {}
 		});
 	}
 

--- a/redis/vibe/db/redis/redis.d
+++ b/redis/vibe/db/redis/redis.d
@@ -140,7 +140,9 @@ final class RedisClient {
 		m_connections.removeUnused((conn) @safe nothrow {
 			try {
                  conn.m_conn.close();
-			 } catch(Exception e) {}
+			 } catch(Exception e) {
+				 logDebug("Failed to close unused Redis connection: %s", e.msg);
+			 }
 		});
 	}
 

--- a/redis/vibe/db/redis/sessionstore.d
+++ b/redis/vibe/db/redis/sessionstore.d
@@ -26,6 +26,14 @@ final class RedisSessionStore : SessionStore {
 		m_db = connectRedis(host, port).getDatabase(database);
 	}
 
+	/** Release all connections that are not in use. Call this at the end of
+	 * your program to clean up unused sockets that may be held by the GC.
+	 */
+	void releaseUnusedConnections() @safe
+	{
+		m_db.client.releaseUnusedConnections();
+	}
+
 	/** The duration without access after which a session expires.
 	*/
 	@property Duration expirationTime() const { return m_expirationTime; }

--- a/tests/redis/source/app.d
+++ b/tests/redis/source/app.d
@@ -24,6 +24,9 @@ void runTest()
 		logInfo("Failed to connect to local Redis server. Skipping test.");
 		return;
 	}
+
+	scope(exit) redis.releaseUnusedConnections();
+
 	{
 		auto db = redis.getDatabase(0);
 		db.deleteAll();


### PR DESCRIPTION
See issue #2245. This allows user code to clean up a `RedisClient` or `RedisSessionStore` before exiting the program to prevent messages of leaked eventcore drivers. Not attached to the function name, so if that needs to change, let me know.