### PR TITLE
Fix compiler error with Deimos OpenSSL 1.1.0h

### DIFF
--- a/tls/vibe/stream/openssl.d
+++ b/tls/vibe/stream/openssl.d
@@ -115,12 +115,18 @@ static if (OPENSSL_VERSION.startsWith("1.1")) {
 	alias get_rfc3526_prime_2048 = BN_get_rfc3526_prime_2048;
 
 	// #  define sk_num OPENSSL_sk_num
-	extern(C) int OPENSSL_sk_num(const void *);
-	extern(C) int sk_num(const(_STACK)* p) { return OPENSSL_sk_num(p); }
+	static if (!is(typeof(OPENSSL_sk_num)))
+	{
+		extern(C) int OPENSSL_sk_num(const void *);
+		extern(C) int sk_num(const(_STACK)* p) { return OPENSSL_sk_num(p); }
+	}
 
 	// #  define sk_value OPENSSL_sk_value
-	extern(C) void *OPENSSL_sk_value(const void *, int);
-	extern(C) void* sk_value(const(_STACK)* p, int i) { return OPENSSL_sk_value(p, i); }
+	static if (!is(typeof(OPENSSL_sk_value)))
+	{
+		extern(C) void *OPENSSL_sk_value(const void *, int);
+		extern(C) void* sk_value(const(_STACK)* p, int i) { return OPENSSL_sk_value(p, i); }
+	}
 
 	private enum SSL_CTRL_SET_MIN_PROTO_VERSION = 123;
 


### PR DESCRIPTION
see https://github.com/ldc-developers/ldc/issues/3205

For OpenSSL 1.1.0h those definitions are conflicting.

The whole OpenSSL configuration on Windows at least is a real mess... 
https://github.com/vibe-d/vibe.d/issues/2284