### PR TITLE
WebSocket improvements

### DIFF
--- a/http/vibe/http/websockets.d
+++ b/http/vibe/http/websockets.d
@@ -140,6 +140,14 @@ void connectWebSocket(URL url, scope WebSocketHandshakeDelegate del, const(HTTPC
 		settings
 	);
 }
+/// ditto
+void connectWebSocket(URL url, scope void delegate(scope WebSocket) @system del, const(HTTPClientSettings) settings = defaultSettings)
+@system {
+	connectWebSocket(url, (scope ws) nothrow {
+		try del(ws);
+		catch (Exception e) logWarn("WebSocket handler failed: %s", e.msg);
+	}, settings);
+}
 /// Scheduled for deprecation - use a `@safe` callback instead.
 void connectWebSocket(URL url, scope void delegate(scope WebSocket) @system nothrow del, const(HTTPClientSettings) settings = defaultSettings)
 @system {
@@ -148,14 +156,6 @@ void connectWebSocket(URL url, scope void delegate(scope WebSocket) @system noth
 /// Scheduled for deprecation - use a `nothrow` callback instead.
 void connectWebSocket(URL url, scope void delegate(scope WebSocket) @safe del, const(HTTPClientSettings) settings = defaultSettings)
 @safe {
-	connectWebSocket(url, (scope ws) nothrow {
-		try del(ws);
-		catch (Exception e) logWarn("WebSocket handler failed: %s", e.msg);
-	}, settings);
-}
-/// ditto
-void connectWebSocket(URL url, scope void delegate(scope WebSocket) @system del, const(HTTPClientSettings) settings = defaultSettings)
-@system {
 	connectWebSocket(url, (scope ws) nothrow {
 		try del(ws);
 		catch (Exception e) logWarn("WebSocket handler failed: %s", e.msg);

--- a/http/vibe/http/websockets.d
+++ b/http/vibe/http/websockets.d
@@ -97,7 +97,7 @@ WebSocket connectWebSocket(URL url, const(HTTPClientSettings) settings = default
 		req.headers["Connection"] = "Upgrade";
 		req.headers["Sec-WebSocket-Version"] = "13";
 		req.headers["Sec-WebSocket-Key"] = challengeKey;
-	});
+	}, settings);
 
 	enforce(res.statusCode == HTTPStatus.switchingProtocols, "Server didn't accept the protocol upgrade request.");
 
@@ -136,7 +136,8 @@ void connectWebSocket(URL url, scope WebSocketHandshakeDelegate del, const(HTTPC
 				del(ws);
 				if (ws.connected) ws.close();
 			});
-		}
+		},
+		settings
 	);
 }
 /// Scheduled for deprecation - use a `@safe` callback instead.


### PR DESCRIPTION
Fixes HTTP client settings handling and adds `connectWebSocketEx` with the possibility to control request headers. This replaces #2374. Note that the new function name was necessary to avoid ambiguous call errors when using the delegate based overload with an anonymous, type inferred callback.