### PR TITLE
fix: use current UUID type

### DIFF
--- a/data/vibe/data/bson.d
+++ b/data/vibe/data/bson.d
@@ -798,7 +798,7 @@ struct BsonBinData {
 		generic = 0x00,
 		function_ = 0x01,
 		binaryOld = 0x02,
-		uuid = 0x03,
+		uuid = 0x04,
 		md5 = 0x05,
 		userDefined = 0x80,
 


### PR DESCRIPTION
std.uuid.UUID as being converted to the legacy BSON UUID type.

BREAKING CHANGE: type change from BinData 0x03 to 0x04 for std.uuid.UUID