### PR TITLE
Enforce that the mongo cursor is not called during the GC collection

### DIFF
--- a/mongodb/vibe/db/mongo/cursor.d
+++ b/mongodb/vibe/db/mongo/cursor.d
@@ -293,6 +293,12 @@ private abstract class MongoCursorData(DocType) {
 	final private void destroy()
 	@safe {
 		if (m_cursor == 0) return;
+		
+		debug {
+			import vibe.internal.allocator : ensureNotInGC;
+			ensureNotInGC!(typeof(this))();
+		}
+		
 		auto conn = m_client.lockConnection();
 		conn.killCursors(() @trusted { return (&m_cursor)[0 .. 1]; } ());
 		m_cursor = 0;


### PR DESCRIPTION
The cursor is failing when is used in a class. This prs should help with debugging of those weird crashes.

depends on https://github.com/vibe-d/vibe-core/pull/186