### PR TITLE
Remove obsolete VibeCustomMain version from examples/tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,7 +44,7 @@ d:
   - dmd-2.085.0,dub # 2.085.1 has a regression
   - dmd-2.084.1,dub
   - dmd-2.078.3,dub
-  - dmd-beta
+  - dmd-beta,dub
 
 env:
   - VIBED_DRIVER=vibe-core PARTS=builds,unittests,examples,tests,mongo

--- a/examples/bench-http-request/dub.json
+++ b/examples/bench-http-request/dub.json
@@ -3,5 +3,5 @@
 	"dependencies": {
 		"vibe-d:http": {"path": "../../"}
 	},
-	"versions": ["VibeCustomMain", "VibeManualMemoryManagement"]
+	"versions": [ "VibeManualMemoryManagement" ]
 }

--- a/examples/bench-mongodb/dub.json
+++ b/examples/bench-mongodb/dub.json
@@ -4,5 +4,5 @@
 	"dependencies": {
 		"vibe-d:mongodb": {"path": "../../"}
 	},
-	"versions": ["VibeCustomMain", "VibeRouterTreeMatch"]
+	"versions": [ "VibeRouterTreeMatch" ]
 }

--- a/examples/bench-urlrouter/dub.json
+++ b/examples/bench-urlrouter/dub.json
@@ -4,5 +4,5 @@
 	"dependencies": {
 		"vibe-d:http": {"path": "../../"}
 	},
-	"versions": ["VibeCustomMain", "VibeRouterTreeMatch"]
+	"versions": [ "VibeRouterTreeMatch" ]
 }

--- a/examples/daytime/dub.json
+++ b/examples/daytime/dub.json
@@ -3,6 +3,5 @@
 	"description": "Requests the current time using the daytime protocol.",
 	"dependencies": {
 		"vibe-d:stream": {"path": "../../"}
-	},
-	"versions": ["VibeCustomMain"]
+	}
 }

--- a/examples/download/dub.json
+++ b/examples/download/dub.json
@@ -3,6 +3,5 @@
 	"description": "Requests a page using the download() function.",
 	"dependencies": {
 		"vibe-d:http": {"path": "../../"}
-	},
-	"versions": ["VibeCustomMain"]
+	}
 }

--- a/examples/http_request/dub.json
+++ b/examples/http_request/dub.json
@@ -4,6 +4,5 @@
 	"authors": [ "Sönke Ludwig" ],
 	"dependencies": {
 		"vibe-d:http": {"path": "../../"}
-	},
-	"versions": ["VibeCustomMain"]
+	}
 }

--- a/examples/http_request_digest/dub.json
+++ b/examples/http_request_digest/dub.json
@@ -4,6 +4,5 @@
 	"authors": [ "Sönke Ludwig" ],
 	"dependencies": {
 		"vibe-d:http": {"path": "../../"}
-	},
-	"versions": ["VibeCustomMain"]
+	}
 }

--- a/examples/json/dub.json
+++ b/examples/json/dub.json
@@ -4,6 +4,5 @@
 	"dependencies": {
 		"vibe-d:data": {"path": "../../"},
 		"vibe-d:core": {"path": "../../"}
-	},
-	"versions": ["VibeCustomMain"]
+	}
 }

--- a/examples/mongodb/dub.json
+++ b/examples/mongodb/dub.json
@@ -3,6 +3,5 @@
 	"description": "Basic MongoDB usage example.",
 	"dependencies": {
 		"vibe-d:mongodb": {"path": "../../"}
-	},
-	"versions": ["VibeCustomMain"]
+	}
 }

--- a/examples/redis/dub.json
+++ b/examples/redis/dub.json
@@ -3,6 +3,5 @@
 	"description": "Basic Redis usage example.",
 	"dependencies": {
 		"vibe-d:redis": {"path": "../../"}
-	},
-	"versions": ["VibeCustomMain"]
+	}
 }

--- a/examples/sendmail/dub.json
+++ b/examples/sendmail/dub.json
@@ -3,6 +3,5 @@
 	"description": "Sends a mail (be sure to adjust addresses before running).",
 	"dependencies": {
 		"vibe-d:mail": {"path": "../../"}
-	},
-	"versions": ["VibeCustomMain"]
+	}
 }

--- a/examples/serialization/dub.json
+++ b/examples/serialization/dub.json
@@ -4,6 +4,5 @@
 	"dependencies": {
 		"vibe-d:core": {"path": "../../"},
 		"vibe-d:data": {"path": "../../"}
-	},
-	"versions": ["VibeCustomMain"]
+	}
 }

--- a/tests/args/dub.json
+++ b/tests/args/dub.json
@@ -3,6 +3,5 @@
     "description": "Command-line argument test",
     "dependencies": {
         "vibe-d": {"version": "~master", "path": "../../"}
-    },
-    "versions": ["VibeCustomMain"]
+    }
 }

--- a/tests/dirwatcher/dub.json
+++ b/tests/dirwatcher/dub.json
@@ -3,6 +3,5 @@
 	"description": "Test for vibe.d's DirectoryWatcher.",
 	"dependencies": {
 		"vibe-d": {"version": "~master", "path": "../../"}
-	},
-	"versions": ["VibeCustomMain"]
+	}
 }

--- a/tests/mongodb/insert-remove-aggregate/dub.json
+++ b/tests/mongodb/insert-remove-aggregate/dub.json
@@ -3,6 +3,5 @@
     "description": "High level MongoDB test for vibe.d",
     "dependencies": {
         "vibe-d:mongodb": {"path": "../../../"}
-    },
-    "versions": ["VibeCustomMain"]
+    }
 }

--- a/tests/redis/dub.json
+++ b/tests/redis/dub.json
@@ -3,6 +3,5 @@
     "description": "High level Redis test for vibe.d",
     "dependencies": {
         "vibe-d:redis": {"path": "../../"}
-    },
-    "versions": ["VibeCustomMain"]
+    }
 }

--- a/tests/restclient/dub.json
+++ b/tests/restclient/dub.json
@@ -3,6 +3,5 @@
     "description": "High level REST client test for vibe.d",
     "dependencies": {
         "vibe-d": {"version": "~master", "path": "../../"}
-    },
-    "versions": ["VibeCustomMain"]
+    }
 }

--- a/tests/restcollections/dub.json
+++ b/tests/restcollections/dub.json
@@ -3,6 +3,5 @@
     "description": "High level REST client test for vibe.d",
     "dependencies": {
         "vibe-d": {"version": "~master", "path": "../../"}
-    },
-    "versions": ["VibeCustomMain"]
+    }
 }

--- a/tests/tcpproxy/dub.json
+++ b/tests/tcpproxy/dub.json
@@ -3,6 +3,5 @@
     "description": "TCP proxy test",
     "dependencies": {
         "vibe-d": {"version": "~master", "path": "../../"}
-    },
-    "versions": ["VibeCustomMain"]
+    }
 }

--- a/tests/tls/dub.json
+++ b/tests/tls/dub.json
@@ -3,6 +3,5 @@
     "description": "TLS tunnel and certificate test",
     "dependencies": {
         "vibe-d": {"path": "../../"}
-    },
-    "versions": ["VibeCustomMain"]
+    }
 }


### PR DESCRIPTION
It is gone since v0.7.26, that is 4 years ago.