### PR TITLE
Redis pubsub fixes

### DIFF
--- a/redis/vibe/db/redis/redis.d
+++ b/redis/vibe/db/redis/redis.d
@@ -1077,14 +1077,9 @@ final class RedisSubscriberImpl {
 			logTrace("Redis listener exiting");
 			// More publish commands may be sent to this connection after recycling it, so we
 			// actively destroy it
-			Action act;
-			// wait for the listener helper to send its stop message
-			while (act != Action.STOP)
-				act = () @trusted { return receiveOnly!Action(); } ();
 			m_lockedConnection.conn.close();
 			m_lockedConnection.destroy();
 			m_listening = false;
-			return;
 		}
 		// http://redis.io/topics/pubsub
 		/**

--- a/tests/vibe.db.redis.redis.pr2407/dub.json
+++ b/tests/vibe.db.redis.redis.pr2407/dub.json
@@ -1,0 +1,8 @@
+{
+    "name": "tests",
+    "description": "Redis pubsub tests",
+    "dependencies": {
+        "vibe-d:core": {"path": "../../"},
+        "vibe-d:redis": {"path": "../../"}
+    }
+}

--- a/tests/vibe.db.redis.redis.pr2407/source/app.d
+++ b/tests/vibe.db.redis.redis.pr2407/source/app.d
@@ -1,0 +1,40 @@
+import vibe.db.redis.redis;
+import vibe.core.core;
+import vibe.core.log;
+
+enum redisPort = 16379;
+
+void main()
+{
+	runTask(&redisServerMock);
+	runTask(&listenRedis);
+	runApplication();
+}
+
+void redisServerMock()
+{
+	listenTCP(redisPort, (conn) {
+		conn.write("*3\r\n$9\r\nsubscribe\r\n$4\r\ntest\r\n:1\r\n");
+		conn.write("*3\r\n$7\r\nmessage\r\n$4\r\ntest\r\n$5\r\nhello\r\n");
+
+		// server terminates unexpectedly
+		conn.close();
+	});
+}
+
+void listenRedis()
+{
+	auto redis = connectRedis("127.0.0.1", redisPort);
+	auto subs = redis.createSubscriber();
+	subs.subscribe("test");
+
+	logInfo("subscribed");
+
+	auto task = subs.listen((string channel, string message) {
+		logInfo("received message on %s: %s", channel, message);
+	});
+	task.join();
+
+	logInfo("done listening");
+	exitEventLoop();
+}


### PR DESCRIPTION
This fixes two issues in redis pubsub implementation.

* The first issue (solved in 1st commit) is an infinite loop (that causes 100% CPU) that happens when the redis *server* exits while listening to pubsub messages.
The following code shows a reproduction case:
```
import vibe.db.redis.redis;
import vibe.core.core;
import vibe.core.log;

void main() {
	runTask(&listenRedis);
	runApplication();
}

void listenRedis() {
	auto redis = connectRedis("127.0.0.1");
	auto subs = redis.createSubscriber();
	subs.subscribe("test");

	logInfo("subscribed");

	auto task = subs.listen((string channel, string message) {
		logInfo("received message on %s: %s", channel, message);
	});
	task.join();

	logInfo("done listening");
}
```
Redis server must be stopped to face the issue.

* Second issue (solved in 2nd commit) is that the task doesn't join back or terminate because the code in `teardown` was waiting for `Action.STOP` message, but that will never arrive, because it was already consumed by the `handler`. I don't think there are cases when that is not the case. 