### PR TITLE
data/json: Fix a DIP25 violation

### DIFF
--- a/data/vibe/data/json.d
+++ b/data/vibe/data/json.d
@@ -255,7 +255,7 @@ struct Json {
 	/**
 		Allows assignment of D values to a JSON value.
 	*/
-	ref Json opAssign(Json v)
+	ref Json opAssign(Json v) return
 	{
 		if (v.type != Type.bigInt)
 			runDestructors();


### PR DESCRIPTION
Pretty trivial. Not adding `-preview=dip25` to `dub.sdl` because it would need to be added to all subpackages to be useful (see https://github.com/dlang/dub/issues/1881).
I'm currently trying to see if we can get this enabled by default, since it's been 5 years the feature was introduced.