### PR TITLE
Detect half-closed connections in the HTTP client.

### DIFF
--- a/http/vibe/http/client.d
+++ b/http/vibe/http/client.d
@@ -635,7 +635,7 @@ final class HTTPClient {
 		m_requesting = true;
 		scope(exit) m_requesting = false;
 
-		if (!m_conn || !m_conn.connected) {
+		if (!m_conn || !m_conn.connected || m_conn.waitForDataEx(0.seconds) == WaitForDataStatus.noMoreData) {
 			if (m_conn) {
 				m_conn.close(); // make sure all resources are freed
 				m_conn = TCPConnection.init;


### PR DESCRIPTION
Previously would attempt to write another request to a connection that had already been shut down by the server (server-to-client direction).