### PR TITLE
Mongo documentation & auth improvements

### DIFF
--- a/mongodb/vibe/db/mongo/client.d
+++ b/mongodb/vibe/db/mongo/client.d
@@ -26,7 +26,7 @@ import std.range;
 	Represents a connection to a MongoDB server.
 
 	Note that this class uses a ConnectionPool internally to create and reuse
-	network conections to the server as necessary. It should be reused for all
+	network connections to the server as necessary. It should be reused for all
 	fibers in a thread for optimum performance in high concurrency scenarios.
  */
 final class MongoClient {
@@ -107,7 +107,7 @@ final class MongoClient {
 		conjunction with MongoDatabase.opIndex.
 
 		Returns:
-			MongoCollection for the given combined database and collectiion name(path)
+			MongoCollection for the given combined database and collection name (path)
 
 		Examples:
 			---

--- a/mongodb/vibe/db/mongo/collection.d
+++ b/mongodb/vibe/db/mongo/collection.d
@@ -73,7 +73,7 @@ struct MongoCollection {
 	/**
 	  Performs an update operation on documents matching 'selector', updating them with 'update'.
 
-	  Throws: Exception if a DB communication error occured.
+	  Throws: Exception if a DB communication error occurred.
 	  See_Also: $(LINK http://www.mongodb.org/display/DOCS/Updating)
 	 */
 	void update(T, U)(T selector, U update, UpdateFlags flags = UpdateFlags.None)
@@ -92,7 +92,7 @@ struct MongoCollection {
 	  automatically. If you need to know the IDs of the inserted documents,
 	  you need to generate them locally.
 
-	  Throws: Exception if a DB communication error occured.
+	  Throws: Exception if a DB communication error occurred.
 	  See_Also: $(LINK http://www.mongodb.org/display/DOCS/Inserting)
 	 */
 	void insert(T)(T document_or_documents, InsertFlags flags = InsertFlags.None)
@@ -132,7 +132,7 @@ struct MongoCollection {
 			when no document matched. For types R that are not Bson, the returned value is either
 			of type $(D R), or of type $(Nullable!R), if $(D R) is not a reference/pointer type.
 
-		Throws: Exception if a DB communication error or a query error occured.
+		Throws: Exception if a DB communication error or a query error occurred.
 		See_Also: $(LINK http://www.mongodb.org/display/DOCS/Querying)
 	 */
 	auto findOne(R = Bson, T, U)(T query, U returnFieldSelector, QueryFlags flags = QueryFlags.None)
@@ -162,7 +162,7 @@ struct MongoCollection {
 	/**
 	  Removes documents from the collection.
 
-	  Throws: Exception if a DB communication error occured.
+	  Throws: Exception if a DB communication error occurred.
 	  See_Also: $(LINK http://www.mongodb.org/display/DOCS/Removing)
 	 */
 	void remove(T)(T selector, DeleteFlags flags = DeleteFlags.None)
@@ -262,7 +262,7 @@ struct MongoCollection {
 	/**
 		Counts the results of the specified query expression.
 
-		Throws Exception if a DB communication error occured.
+		Throws Exception if a DB communication error occurred.
 		See_Also: $(LINK http://www.mongodb.org/display/DOCS/Advanced+Queries#AdvancedQueries-{{count%28%29}})
 	*/
 	ulong count(T)(T query)
@@ -300,7 +300,7 @@ struct MongoCollection {
 			value is either a single `Bson` array value or a `MongoCursor`
 			(input range) of the requested document type.
 
-		Throws: Exception if a DB communication error occured
+		Throws: Exception if a DB communication error occurred.
 
 		See_Also: $(LINK http://docs.mongodb.org/manual/reference/method/db.collection.aggregate)
 	*/
@@ -373,7 +373,7 @@ struct MongoCollection {
 			args ~= serializeToBson(["$sort": ["total": -1]]);
 
 			AggregateOptions options;
-			options.cursor.batchSize = 10; // prefetch the first 10 results
+			options.cursor.batchSize = 10; // pre-fetch the first 10 results
 			auto results = db["coll"].aggregate(args, options);
 		}
 	}
@@ -648,7 +648,7 @@ struct ReadConcern {
 }
 
 /**
-  Collation allows users to specify language-specific rules for string comparison, such as rules for lettercase and accent marks.
+  Collation allows users to specify language-specific rules for string comparison, such as rules for letter-case and accent marks.
 
   See_Also: $(LINK https://docs.mongodb.com/manual/reference/collation/)
  */

--- a/mongodb/vibe/db/mongo/connection.d
+++ b/mongodb/vibe/db/mongo/connection.d
@@ -324,7 +324,7 @@ final class MongoConnection {
 	{
 		// Though higher level abstraction level by concept, this function
 		// is implemented here to allow to check errors upon every request
-		// on conncetion level.
+		// on connection level.
 
 		Bson command_and_options = Bson.emptyObject;
 		command_and_options["getLastError"] = Bson(1.0);

--- a/mongodb/vibe/db/mongo/connection.d
+++ b/mongodb/vibe/db/mongo/connection.d
@@ -156,6 +156,8 @@ final class MongoConnection {
 
 	void connect()
 	{
+		bool isTLS;
+
 		/*
 		 * TODO: Connect to one of the specified hosts taking into consideration
 		 * options such as connect timeouts and so on.
@@ -177,6 +179,7 @@ final class MongoConnection {
 				}
 
 				m_stream = createTLSStream(m_conn, ctx, m_settings.hosts[0].name);
+				isTLS = true;
 			}
 			else {
 				m_stream = m_conn;
@@ -223,32 +226,51 @@ final class MongoConnection {
 			});
 
 		m_bytesRead = 0;
-		if(m_settings.digest != string.init)
+		auto authMechanism = m_settings.authMechanism;
+		if (authMechanism == MongoAuthMechanism.none)
 		{
-			m_isAuthenticating = true;
-			scope (exit)
-				m_isAuthenticating = false;
-			if ((m_settings.authMechanism == MongoAuthMechanism.mongoDBCR
-					&& !m_description.satisfiesVersion(WireVersion.v40)) // removed in MongoDB 4.0
-				|| !m_description.satisfiesVersion(WireVersion.v30)) // deprecated in MongoDB 3.0
-				authenticate(); // use old mechanism if explicitly stated
-			else {
-				/**
-				SCRAM-SHA-1 was released in March 2015 and on a properly
-				configured Mongo instance Authentication.none is disabled.
-				However, as a fallback to avoid breakage with old setups,
-				no authentication is tried in case of an error.
-				*/
-				try
-					scramAuthenticate(); // scram-sha-1 is default in version v3.0+
-				catch (MongoAuthException e)
-					authenticate(); // fall back if scram-sha-1 fails
+			if (m_settings.sslPEMKeyFile != null && m_description.satisfiesVersion(WireVersion.v26))
+			{
+				authMechanism = MongoAuthMechanism.mongoDBX509;
 			}
-
+			else if (m_settings.digest.length)
+			{
+				// SCRAM-SHA-1 default since 3.0, otherwise use legacy authentication
+				if (m_description.satisfiesVersion(WireVersion.v30))
+					authMechanism = MongoAuthMechanism.scramSHA1;
+				else
+					authMechanism = MongoAuthMechanism.mongoDBCR;
+			}
 		}
-		else if (m_settings.sslPEMKeyFile != null && m_settings.username != null)
+
+		if (authMechanism == MongoAuthMechanism.mongoDBCR && m_description.satisfiesVersion(WireVersion.v40))
+			throw new MongoAuthException("Trying to force MONGODB-CR authentication on a >=4.0 server not supported");
+
+		if (authMechanism == MongoAuthMechanism.scramSHA1 && !m_description.satisfiesVersion(WireVersion.v30))
+			throw new MongoAuthException("Trying to force SCRAM-SHA-1 authentication on a <3.0 server not supported");
+
+		if (authMechanism == MongoAuthMechanism.mongoDBX509 && !m_description.satisfiesVersion(WireVersion.v26))
+			throw new MongoAuthException("Trying to force MONGODB-X509 authentication on a <2.6 server not supported");
+
+		if (authMechanism == MongoAuthMechanism.mongoDBX509 && !isTLS)
+			throw new MongoAuthException("Trying to force MONGODB-X509 authentication, but didn't use ssl!");
+
+		m_isAuthenticating = true;
+		scope (exit)
+			m_isAuthenticating = false;
+		final switch (authMechanism)
 		{
+		case MongoAuthMechanism.none:
+			break;
+		case MongoAuthMechanism.mongoDBX509:
 			certAuthenticate();
+			break;
+		case MongoAuthMechanism.scramSHA1:
+			scramAuthenticate();
+			break;
+		case MongoAuthMechanism.mongoDBCR:
+			authenticate();
+			break;
 		}
 	}
 

--- a/mongodb/vibe/db/mongo/cursor.d
+++ b/mongodb/vibe/db/mongo/cursor.d
@@ -71,7 +71,7 @@ struct MongoCursor(DocType = Bson) {
 	/**
 		Controls the order in which the query returns matching documents.
 
-		This method must be called before starting to iterate, or an exeption
+		This method must be called before starting to iterate, or an exception
 		will be thrown. If multiple calls to $(D sort()) are issued, only
 		the last one will have an effect.
 
@@ -80,7 +80,7 @@ struct MongoCursor(DocType = Bson) {
 				of the result. This BSON object must be structured according to
 				the MongoDB documentation (see below).
 
-		Returns: Reference to the modified original curser instance.
+		Returns: Reference to the modified original cursor instance.
 
 		Throws:
 			An exception if there is a query or communication error.
@@ -118,7 +118,7 @@ struct MongoCursor(DocType = Bson) {
 	/**
 		Limits the number of documents that the cursor returns.
 
-		This method must be called before beginnig iteration in order to have
+		This method must be called before beginning iteration in order to have
 		effect. If multiple calls to limit() are made, the one with the lowest
 		limit will be chosen.
 
@@ -139,7 +139,7 @@ struct MongoCursor(DocType = Bson) {
 	/**
 		Skips a given number of elements at the beginning of the cursor.
 
-		This method must be called before beginnig iteration in order to have
+		This method must be called before beginning iteration in order to have
 		effect. If multiple calls to skip() are made, the one with the maximum
 		number will be chosen.
 

--- a/mongodb/vibe/db/mongo/mongo.d
+++ b/mongodb/vibe/db/mongo/mongo.d
@@ -7,8 +7,10 @@
 	known from the JavaScript driver, but these can usually be implemented in
 	terms of MongoDatabase.runCommand or MongoCollection.find. Since the
 	official documentation is lacking in some places, it may be necessary to use
-	a network sniffer to monitor what exectly needs to be sent. MongoDB has a
+	a network sniffer to monitor what exactly needs to be sent. MongoDB has a
 	dedicated utility for this called $(LINK2 http://docs.mongodb.org/manual/reference/program/mongosniff/ mongosniff).
+
+	As of 2014 there is proper documentation on $(LINK https://github.com/mongodb/specifications).
 
 	Copyright: © 2012-2013 Sönke Ludwig
 	License: Subject to the terms of the MIT license, as written in the included LICENSE.txt file.

--- a/mongodb/vibe/db/mongo/settings.d
+++ b/mongodb/vibe/db/mongo/settings.d
@@ -350,6 +350,41 @@ class MongoClientSettings
 	@safe {
 		return md5Of(username ~ ":mongo:" ~ password).toHexString().idup.toLower();
 	}
+
+	/**
+	 * Sets the username and the digest string in this MongoClientSettings
+	 * instance.
+	 */
+	void authenticatePassword(string username, string password)
+	@safe {
+		this.username = username;
+		this.digest = MongoClientSettings.makeDigest(username, password);
+	}
+
+	/**
+	 * Sets ssl, the username, the PEM key file and the trusted CA file in this
+	 * MongoClientSettings instance.
+	 *
+	 * Params:
+	 *   username = The username as provided in the cert file like
+	 *   `"C=IS,ST=Reykjavik,L=Reykjavik,O=MongoDB,OU=Drivers,CN=client"`.
+	 *
+	 *   The username can be blank if connecting to MongoDB 3.4 or above.
+	 *
+	 *   sslPEMKeyFile = Path to a certificate with private key and certificate
+	 *   chain to connect with.
+	 *
+	 *   sslCAFile = Optional path to a trusted certificate authority file for
+	 *   verifying the remote certificate.
+	 */
+	void authenticateSSL(string username, string sslPEMKeyFile, string sslCAFile = null)
+	@safe {
+		this.ssl = true;
+		this.digest = null;
+		this.username = username;
+		this.sslPEMKeyFile = sslPEMKeyFile;
+		this.sslCAFile = sslCAFile;
+	}
 }
 
 struct MongoHost

--- a/mongodb/vibe/db/mongo/settings.d
+++ b/mongodb/vibe/db/mongo/settings.d
@@ -165,6 +165,7 @@ bool parseMongoDBUrl(out MongoClientSettings cfg, string url)
 				case "journal": setBool(cfg.journal); break;
 				case "connecttimeoutms": setLong(cfg.connectTimeoutMS); warnNotImplemented(); break;
 				case "sockettimeoutms": setLong(cfg.socketTimeoutMS); warnNotImplemented(); break;
+				case "tls": setBool(cfg.ssl); break;
 				case "ssl": setBool(cfg.ssl); break;
 				case "sslverifycertificate": setBool(cfg.sslverifycertificate); break;
 				case "authmechanism": cfg.authMechanism = parseAuthMechanism(value); break;

--- a/mongodb/vibe/db/mongo/settings.d
+++ b/mongodb/vibe/db/mongo/settings.d
@@ -302,11 +302,43 @@ unittest
 	assert(cfg.hosts[0].port == 27017);
 }
 
+/**
+ * Describes a vibe.d supported authentication mechanism to use on client
+ * connection to a MongoDB server.
+ */
 enum MongoAuthMechanism
 {
+	/**
+	 * Use no auth mechanism. If a digest or ssl certificate is given this
+	 * defaults to trying the recommend auth mechanisms depending on server
+	 * version and input parameters.
+	 */
 	none,
+
+	/**
+	 * Use SCRAM-SHA-1 as defined in [RFC 5802](http://tools.ietf.org/html/rfc5802)
+	 *
+	 * This is the default when a password is provided. In the future other
+	 * scram algorithms may be implemented and selectable through these values.
+	 *
+	 * MongoDB: 3.0–
+	 */
 	scramSHA1,
+
+	/**
+	 * Forces login through the legacy MONGODB-CR authentication mechanism. This
+	 * mechanism is a nonce and MD5 based system.
+	 *
+	 * MongoDB: 1.4–4.0 (deprecated 3.0)
+	 */
 	mongoDBCR,
+
+	/**
+	 * Use an X.509 certificate to authenticate. Only works if digest is set to
+	 * null or empty string in the MongoClientSettings.
+	 *
+	 * MongoDB: 2.6–
+	 */
 	mongoDBX509
 }
 
@@ -464,11 +496,11 @@ class MongoClientSettings
 	string sslCAFile;
 
 	/**
-	 * Prefer to use this authentication mechanism.
+	 * Use the given authentication mechanism when connecting to the server. If
+	 * unsupported by the server, throw a MongoAuthException.
 	 *
-	 * Note: this only supports forcing MongoDB-CR authentication on <4.0
-	 * servers, has no effect otherwise. To use SSL certificate authentication,
-	 * unset the digest string or use $(LREF authenticateSSL).
+	 * If set to none, but digest or sslPEMKeyFile are set, this automatically
+	 * determines a suitable authentication mechanism based on server version.
 	 */
 	MongoAuthMechanism authMechanism;
 
@@ -528,8 +560,11 @@ class MongoClientSettings
 	}
 }
 
+/// Describes a host we might be able to connect to
 struct MongoHost
 {
+	/// The host name or IP address of the remote MongoDB server.
 	string name;
+	/// The port of the MongoDB server. See `MongoClientSettings.defaultPort`.
 	ushort port;
 }

--- a/mongodb/vibe/db/mongo/settings.d
+++ b/mongodb/vibe/db/mongo/settings.d
@@ -40,7 +40,7 @@ bool parseMongoDBUrl(out MongoClientSettings cfg, string url)
 
 	cfg = new MongoClientSettings();
 
-	string tmpUrl = url[0..$]; // Slice of the url (not a copy)
+	string tmpUrl = url[0..$]; // Slice of the URL (not a copy)
 
 	if( !startsWith(tmpUrl, "mongodb://") )
 	{

--- a/tests/mongodb/insert-remove-aggregate/source/app.d
+++ b/tests/mongodb/insert-remove-aggregate/source/app.d
@@ -8,7 +8,7 @@ import vibe.core.log;
 import vibe.data.bson;
 import vibe.db.mongo.mongo;
 
-import std.algorithm : canFind, map, equal;
+import std.algorithm : canFind, equal, map, sort;
 import std.conv : to;
 import std.encoding : sanitize;
 
@@ -84,7 +84,9 @@ void runTest(ushort port)
 	coll.insert(["a": "first", "b": "bar"]);
 	coll.insert(["a": "second", "b": "baz"]);
 	coll.insert(["a": "second", "b": "bam"]);
-	assert(coll.distinct!string("b", ["a": "first"]).equal(["foo", "bar"]));
+	auto d = coll.distinct!string("b", ["a": "first"]).array;
+	d.sort!"a<b";
+	assert(d == ["bar", "foo"]);
 }
 
 int main(string[] args)


### PR DESCRIPTION
Functionality-wise this changes a few little things:
- fixes mongodb unittest (distinct giving different order now)
- add tls as alias for the ssl parameter in parsing mongodb urls
- adds authenticatePassword and authenticateSSL methods to avoid issues with wrong usage of field members
- makes makeDigest pure to avoid calling it as member, expecting stuff to happen
- x509 authentication requires a username or forces it to be omitted completely if missing on certain driver specifications
- authentication mechanism generation now follows these strict rules:
  - (if set to none) if a certificate file is given & server is >= 2.6, use X509 authentication
  - (if set to none) otherwise if a digest is given, check server version
    - server version >= 3.0: use SCRAM-SHA-1
    - otherwise use MONGODB-CR
  - if the selected authentication mechanism isn't supported by the MongoDB server version now, throw a MongoAuthException

Otherwise fixes some documentation typos and adds a lot of documentation to the existing MongoClientSettings fields that were previously all undocumented. (which you need to set for the connectMongoDB call overload taking a settings object)