### PR TITLE
meson: remove deleted win32.d from vite_utils_src

### DIFF
--- a/utils/meson.build
+++ b/utils/meson.build
@@ -13,7 +13,6 @@ vibe_utils_src = [
     'vibe/internal/meta/uda.d',
     'vibe/internal/rangeutil.d',
     'vibe/internal/utilallocator.d',
-    'vibe/internal/win32.d',
     'vibe/utils/array.d',
     'vibe/utils/dictionarylist.d',
     'vibe/utils/hashmap.d',


### PR DESCRIPTION
Required after 4f9bbc7f8125ad48dab4f6c74ccd08e61d9aaee6