### PR TITLE
Simplify MongoDB aggregate serialization

### DIFF
--- a/data/vibe/data/bson.d
+++ b/data/vibe/data/bson.d
@@ -567,6 +567,9 @@ struct Bson {
 	}
 	/// ditto
 	void opIndexAssign(T)(in T value, string idx){
+		// WARNING: it is ABSOLUTELY ESSENTIAL that ordering is not changed!!!
+		// MongoDB depends on ordering of the Bson maps.
+
 		auto newcont = appender!bdata_t();
 		checkType(Type.object);
 		auto d = m_data[4 .. $];


### PR DESCRIPTION
The new `@embedNullable` UDA can be used for serialization to ignore unset fields. This commit replaces previous manual code performing these kinds of checks to allow for easier future modification.

Also skips cursor field when explain is turned on because that's recommended to be done as a driver.

This PR also slightly extends/formats the documentation on the fields.