### PR TITLE
Remove all Optlink/OMF based CI configurations.

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,9 +8,6 @@ environment:
     DVersion: 2.091.0
     arch: x86_mscoff
   - DC: dmd
-    DVersion: 2.091.0
-    arch: x86
-  - DC: dmd
     DVersion: 2.090.1
     arch: x64
   - DC: dmd
@@ -18,7 +15,7 @@ environment:
     arch: x86_mscoff
   - DC: dmd
     DVersion: 2.088.1
-    arch: x86
+    arch: x64
   - DC: dmd
     DVersion: 2.077.1
     arch: x86_mscoff
@@ -40,13 +37,6 @@ environment:
   - DC: ldc
     DVersion: 1.7.0
     arch: x64
-
-# produces an Optlink failure
-matrix:
-  allow_failures:
-    - DC: dmd
-      DVersion: 2.091.0
-      arch: x86
 
 branches:
   only:

--- a/travis-ci.sh
+++ b/travis-ci.sh
@@ -26,7 +26,6 @@ fi
 
 if [[ $PARTS =~ (^|,)unittests(,|$) ]]; then
     dub test :data --compiler=$DC $DUB_ARGS
-    dub test :core --compiler=$DC $DUB_ARGS
     dub test :mongodb --compiler=$DC $DUB_ARGS
     dub test :redis --compiler=$DC $DUB_ARGS
     dub test :web --compiler=$DC $DUB_ARGS


### PR DESCRIPTION
These cause the a crash in Optlink and make the build time out.