### PR TITLE
Travis: Replace v0.7.x with a regex

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,8 @@ addons:
 branches:
   only:
   - master
-  - 0.7.x
+  - /^v\d+\.x\.x$/
+  - /^v\d+\.\d+\.x$/
 
 # Enable core dumps
 before_script:


### PR DESCRIPTION
This will allow branches such as 'v1.x.x' and 'v0.9.x'.
Will merge back into master when `v0.9.2` is out (I'll add `-preview=in` support).