### PR TITLE
Replace randomUUID by securely generated random data for digest authentication.

### DIFF
--- a/http/vibe/http/auth/digest_auth.d
+++ b/http/vibe/http/auth/digest_auth.d
@@ -9,8 +9,9 @@
 */
 module vibe.http.auth.digest_auth;
 
-import vibe.http.server;
 import vibe.core.log;
+import vibe.crypto.cryptorand;
+import vibe.http.server;
 import vibe.inet.url;
 
 import std.base64;
@@ -18,7 +19,6 @@ import std.datetime;
 import std.digest.md;
 import std.exception;
 import std.string;
-import std.uuid;
 
 @safe:
 
@@ -29,12 +29,12 @@ class DigestAuthInfo
 	@safe:
 
 	string realm;
-	ubyte[] secret;
+	ubyte[32] secret;
 	ulong timeout;
 
 	this()
 	{
-		secret = randomUUID().data.dup;
+		secureRNG.read(secret[]);
 		timeout = 300;
 	}
 


### PR DESCRIPTION
randomUUID does not use a secure RNG and exposes potential security issues, namely if sequences of randomly generated UUIDs (or other random data based on the same RNG) in other places of an application are exposed to an attacker, it becomes possible to predict the digest auth secret.

See https://forum.dlang.org/thread/zjmyxudvscfwrkrdabmt@forum.dlang.org