### PR TITLE
Fix HTTP range boundary condition handling

### DIFF
--- a/http/vibe/http/status.d
+++ b/http/vibe/http/status.d
@@ -43,7 +43,7 @@ enum HTTPStatus {
 	requestEntityTooLarge        = 413,
 	requestURITooLarge           = 414,
 	unsupportedMediaType         = 415,
-	requestedrangenotsatisfiable = 416,
+	rangeNotSatisfiable          = 416,
 	expectationFailed            = 417,
 	tooManyRequests              = 429,
 	unavailableForLegalReasons   = 451,
@@ -61,6 +61,7 @@ enum HTTPStatus {
 	failedDependency             = 424,
 	insufficientStorage          = 507,
 
+	requestedrangenotsatisfiable = rangeNotSatisfiable, /// deprecated
 	Continue = continue_, /// deprecated
 	SwitchingProtocols = switchingProtocols, /// deprecated
 	OK = ok, /// deprecated


### PR DESCRIPTION
Previously this would happen:
 - Request:
   ```
   Range: 10-10
   ```
 - Response:
   ```
   Content-Length: 0
   Content-Range: 9-9/11
   ```

now responds with
 - Response:
   ```
   Content-Length: 1
   Content-Range: 10-10/11
   ```

Ranges that cannot be satisfied are now also reported as an error (range start greater than the last byte or range start greater than range end).