### PR TITLE
Fix refcounted FD leak in HTTPClient

### DIFF
--- a/http/vibe/http/client.d
+++ b/http/vibe/http/client.d
@@ -636,10 +636,8 @@ final class HTTPClient {
 		scope(exit) m_requesting = false;
 
 		if (!m_conn || !m_conn.connected || m_conn.waitForDataEx(0.seconds) == WaitForDataStatus.noMoreData) {
-			if (m_conn) {
-				m_conn.close(); // make sure all resources are freed
-				m_conn = TCPConnection.init;
-			}
+			if (m_conn)
+				disconnect(); // make sure all resources are freed
 
 			if (m_settings.proxyURL.host !is null){
 


### PR DESCRIPTION
I've observed that newly added condition `m_conn.waitForDataEx(0.seconds)` returns `noMoreData` even for `EAGAIN` and so leads to disconnects before the new request.
But there is still m_stream set (TLS) which were not destroyed and so there is FD refcount leak.
Calling `disconnect` that handles the stream too worked for me.