### PR TITLE
Fix #2484 - clear  `m_fill` on flush exception

### DIFF
--- a/stream/vibe/stream/wrapper.d
+++ b/stream/vibe/stream/wrapper.d
@@ -309,6 +309,7 @@ struct StreamOutputRange(OutputStream, size_t buffer_size = 256)
 
 	~this()
 	{
+		scope (failure) () @trusted { destroy(m_stream); }(); // workaround for #2484
 		flush();
 	}
 


### PR DESCRIPTION
Well it's a workaround for this particular issue.

Problem is that in `StreamOutputRange` destructor `flush()` is called to make sure that data has been written.
But when exception is thrown in it, destructor won't cleanup what'll normally be cleaned up and so the leak.

I've fixed it by resetting m_fill in a flush itself but it works only when written data are bigger than the internal buffer so flush is called and fails before the destructor.
For this case to work I've added manual `flush()` to `doWriteJsonBody()` so it's called before the destructor.

But there are much more places this can cause random problems and I'm not sure what would be the best approach for this. But throwing exceptions in destructors or allocating in them can easilly lead to `InvalidMemoryOperation` when called from GC (which is not this case).