### PR TITLE
Do not implicitly use deprecated ProxyStream ctor

### DIFF
--- a/http/vibe/http/server.d
+++ b/http/vibe/http/server.d
@@ -486,10 +486,8 @@ HTTPServerResponse createTestHTTPServerResponse(OutputStream data_sink = null,
 		settings.sessionStore = session_store;
 	}
 
-	InterfaceProxy!Stream outstr;
-	if (data_sink && data_mode == TestHTTPResponseMode.plain)
-		outstr = createProxyStream(Stream.init, data_sink);
-	else outstr = createProxyStream(Stream.init, nullSink);
+	InterfaceProxy!Stream outstr = createProxyStream(Stream.init,
+		data_sink && data_mode == TestHTTPResponseMode.plain ? data_sink : nullSink);
 
 	auto ret = new HTTPServerResponse(outstr, InterfaceProxy!ConnectionStream.init,
 		settings, () @trusted { return vibeThreadAllocator(); } ());


### PR DESCRIPTION
```
A deprecation message was triggered in client code because 'opAssign'
was being used, which forwarded to emplace, which forwards to 'std.conv.to',
which attempt to use it.
Instead of constructing then assigning, we not construct directly.
```

This will silence the following messages:
```
vibe-d:http ~master: building configuration "library"...
/usr/local/Cellar/ldc/1.24.0/include/dlang/ldc/std/conv.d(4698,38): Deprecation: constructor vibe.stream.wrapper.ProxyStream.this is deprecated - Use createProxyStream instead.
/usr/local/Cellar/ldc/1.24.0/include/dlang/ldc/std/conv.d(4702,21): Deprecation: constructor vibe.stream.wrapper.ProxyStream.this is deprecated - Use createProxyStream instead.
```