### PR TITLE
Fixing inconsistent error handling in http request

### DIFF
--- a/http/vibe/http/client.d
+++ b/http/vibe/http/client.d
@@ -621,8 +621,6 @@ final class HTTPClient {
 
 			logTrace("HTTP client waiting for response");
 			if (!m_stream.empty) break;
-
-			enforce(i != 1, "Second attempt to send HTTP request failed.");
 		}
 		return has_body;
 	}


### PR DESCRIPTION
The 'Second attempt to send HTTP request failed' should be removed
so the persisntent and not-persistent http requests are handled
the same way. Full discussion is on the issue page

fixes: #2451