### PR TITLE
Silence deprecations related to importing a deprecated symbol

### DIFF
--- a/mongodb/vibe/db/mongo/connection.d
+++ b/mongodb/vibe/db/mongo/connection.d
@@ -118,7 +118,7 @@ class MongoAuthException : MongoException
 final class MongoConnection {
 @safe:
 
-	import vibe.stream.wrapper : StreamOutputRange, streamOutputRange;
+	import vibe.stream.wrapper /* : StreamOutputRange, streamOutputRange */;
 	import vibe.internal.interfaceproxy;
 	import vibe.core.stream : InputStream, Stream;
 


### PR DESCRIPTION
```
Those deprecations are erroneous (it's a compiler bug),
as we only use the type which is not deprecated,
but the function with the same name is leads to a deprecation.
```

I didn't have time to track down the compiler bug yet, but this solves the issue in the meantime.