### PR TITLE
REST: Implement `viaBody`, `viaQuery`, `viaHeader` as parameters UDAs

### DIFF
--- a/tests/rest/source/app.d
+++ b/tests/rest/source/app.d
@@ -370,27 +370,21 @@ interface Example6API
 {
 	@safe:
 
-	// The first parameter of @headerParam is the identifier (must match one of the parameter name).
-	// The second is the name of the field in the header, such as "Accept", "Content-Type", "User-Agent"...
-	@headerParam("auth", "Authorization")
-	@headerParam("tester", "X-Custom-Tester")
-	@headerParam("www", "WWW-Authenticate")
-	string getPortal(string auth,
-					 ref string tester,
-					 out Nullable!string www);
+	// The parameter is the name of the field in the header,
+	// such as "Accept", "Content-Type", "User-Agent"...
+	string getPortal(@viaHeader("Authorization") string auth,
+					 @viaHeader("X-Custom-Tester") ref string tester,
+					 @viaHeader("WWW-Authenticate") out Nullable!string www);
 
-	// As with @headerParam, the first parameter of @queryParam is the identifier.
-	// The second being the field name, e.g for a query such as: 'GET /root/node?foo=bar', "foo" will be the second parameter.
-	@queryParam("fortyTwo", "qparam")
-	string postAnswer(string fortyTwo);
-	// Finally, there is @bodyParam. It works as you expect it to work,
+	// The parameter is the field name, e.g for a query such as:
+	// 'GET /root/node?foo=bar', it will be "foo".
+	string postAnswer(@viaQuery("qparam") string fortyTwo);
+	// Finally, there is `@viaBody`. It works as you expect it to work,
 	// currently serializing passed data as Json and pass them through the body.
-	@bodyParam("myFoo", "parameter")
-	string postConcat(FooType myFoo);
+	string postConcat(@viaBody("parameter") FooType myFoo);
 
-	// expects the entire body
-	@bodyParam("obj")
-	string postConcatBody(FooType obj);
+	// Without a parameter, it will represent the entire body
+	string postConcatBody(@viaBody() FooType obj);
 
 	struct FooType {
 		int a;

--- a/tests/rest/source/app.d
+++ b/tests/rest/source/app.d
@@ -25,6 +25,9 @@ import core.time;
 @rootPathFromName
 interface Example1API
 {
+	// Methods need to be `@safe`:
+	@safe:
+
 	/* Default convention is based on camelCase
 	 */
 
@@ -89,6 +92,8 @@ unittest
 @rootPathFromName
 interface Example2API
 {
+	@safe:
+
 	// Any D data type may be here. Serializer is not configurable and will send all declared fields.
 	// This should be an API-specified type and may or may not be the same as data type used by other application code.
 	struct Aggregate
@@ -145,6 +150,8 @@ unittest
 @rootPathFromName
 interface Example3API
 {
+	@safe:
+
 	/* Available under ./nested_module/
 	 */
 	@property Example3APINested nestedModule();
@@ -158,6 +165,8 @@ interface Example3API
 
 interface Example3APINested
 {
+	@safe:
+
 	/* In this example it will be available under "GET /nested_module/number"
 	 * But this interface does't really know it, it does not care about exact path
 	 *
@@ -216,6 +225,8 @@ unittest
 @rootPathFromName
 interface Example4API
 {
+	@safe:
+
 	/* vibe.web.rest module provides two pre-defined UDA - @path and @method
 	 * You can use any one of those or both. In case @path is used, not method style
 	 * adjustment is made.
@@ -288,11 +299,13 @@ interface Example5API
 {
 	import vibe.web.rest : before, after;
 
+	@safe:
+
 	@before!authenticate("user") @after!addBrackets()
 	string getSecret(int num, User user);
 }
 
-User authenticate(HTTPServerRequest req, HTTPServerResponse res)
+User authenticate(HTTPServerRequest req, HTTPServerResponse res) @safe
 {
 	return User("admin", true);
 }
@@ -303,7 +316,7 @@ struct User
 	bool authorized;
 }
 
-string addBrackets(string result, HTTPServerRequest, HTTPServerResponse)
+string addBrackets(string result, HTTPServerRequest, HTTPServerResponse) @safe
 {
 	return "{" ~ result ~ "}";
 }
@@ -355,6 +368,8 @@ unittest
 @rootPathFromName
 interface Example6API
 {
+	@safe:
+
 	// The first parameter of @headerParam is the identifier (must match one of the parameter name).
 	// The second is the name of the field in the header, such as "Accept", "Content-Type", "User-Agent"...
 	@headerParam("auth", "Authorization")
@@ -437,6 +452,8 @@ unittest
 
 @rootPathFromName
 interface Example7API {
+	@safe:
+
 	// GET /example7_api/
 	// returns a custom JSON response
 	Json get();

--- a/web/vibe/web/common.d
+++ b/web/vibe/web/common.d
@@ -702,17 +702,31 @@ public struct WebParamAttribute {
  * The serialization format is currently not customizable.
  * If no fieldname is given, the entire body is serialized into the object.
  *
+ * There are currently two kinds of symbol to do this: `viaBody` and `bodyParam`.
+ * `viaBody` should be applied to the parameter itself, while `bodyParam`
+ * is applied to the function.
+ * `bodyParam` was introduced long before the D language for UDAs on parameters
+ * (introduced in DMD v2.082.0), and will be deprecated in a future release.
+ *
  * Params:
  *   identifier = The name of the parameter to customize. A compiler error will be issued on mismatch.
  *   field = The name of the field in the JSON object.
  *
  * ----
- * @bodyParam("pack", "package")
- * void ship(int pack);
+ * void ship(@viaBody("package") int pack);
  * // The server will receive the following body for a call to ship(42):
  * // { "package": 42 }
  * ----
  */
+WebParamAttribute viaBody(string field = null)
+@safe {
+	import vibe.web.internal.rest.common : ParameterKind;
+	if (!__ctfe)
+		assert(false, onlyAsUda!__FUNCTION__);
+	return WebParamAttribute(ParameterKind.body_, null, field);
+}
+
+/// Ditto
 WebParamAttribute bodyParam(string identifier, string field) @safe
 in {
 	assert(field.length > 0, "fieldname can't be empty.");
@@ -741,16 +755,30 @@ WebParamAttribute bodyParam(string identifier)
  * If it's an aggregate, it will be serialized as JSON.
  * However, passing aggregate via header isn't a good practice and should be avoided for new production code.
  *
+ * There are currently two kinds of symbol to do this: `viaHeader` and `headerParam`.
+ * `viaHeader` should be applied to the parameter itself, while `headerParam`
+ * is applied to the function.
+ * `headerParam` was introduced long before the D language for UDAs on parameters
+ * (introduced in DMD v2.082.0), and will be deprecated in a future release.
+ *
  * Params:
  *   identifier = The name of the parameter to customize. A compiler error will be issued on mismatch.
  *   field = The name of the header field to use (e.g: 'Accept', 'Content-Type'...).
  *
  * ----
  * // The server will receive the content of the "Authorization" header.
- * @headerParam("auth", "Authorization")
- * void login(string auth);
+ * void login(@viaHeader("Authorization") string auth);
  * ----
  */
+WebParamAttribute viaHeader(string field)
+@safe {
+	import vibe.web.internal.rest.common : ParameterKind;
+	if (!__ctfe)
+		assert(false, onlyAsUda!__FUNCTION__);
+	return WebParamAttribute(ParameterKind.header, null, field);
+}
+
+/// Ditto
 WebParamAttribute headerParam(string identifier, string field)
 @safe {
 	import vibe.web.internal.rest.common : ParameterKind;
@@ -765,6 +793,12 @@ WebParamAttribute headerParam(string identifier, string field)
  * It will be serialized as part of a JSON object, and will go through URL serialization.
  * The serialization format is not customizable.
  *
+ * There are currently two kinds of symbol to do this: `viaQuery` and `queryParam`.
+ * `viaQuery` should be applied to the parameter itself, while `queryParam`
+ * is applied to the function.
+ * `queryParam` was introduced long before the D language for UDAs on parameters
+ * (introduced in DMD v2.082.0), and will be deprecated in a future release.
+ *
  * Params:
  *   identifier = The name of the parameter to customize. A compiler error will be issued on mismatch.
  *   field = The field name to use.
@@ -772,10 +806,18 @@ WebParamAttribute headerParam(string identifier, string field)
  * ----
  * // For a call to postData("D is awesome"), the server will receive the query:
  * // POST /data?test=%22D is awesome%22
- * @queryParam("data", "test")
- * void postData(string data);
+ * void postData(@viaQuery("test") string data);
  * ----
  */
+WebParamAttribute viaQuery(string field)
+@safe {
+	import vibe.web.internal.rest.common : ParameterKind;
+	if (!__ctfe)
+		assert(false, onlyAsUda!__FUNCTION__);
+	return WebParamAttribute(ParameterKind.query, null, field);
+}
+
+/// Ditto
 WebParamAttribute queryParam(string identifier, string field)
 @safe {
 	import vibe.web.internal.rest.common : ParameterKind;


### PR DESCRIPTION
Something I've been wanting for a while, should make user code much more friendly.
The names have changed to avoid weird overrides with the `headerParam` & co functions, but also to make function prototypes shorter.