### PR TITLE
REST: Do not attempt to modify the return value

### DIFF
--- a/web/vibe/web/rest.d
+++ b/web/vibe/web/rest.d
@@ -1603,13 +1603,13 @@ private HTTPServerRequestDelegate jsonMethodHandler(alias Func, size_t ridx, T)(
 				res.writeBody(cast(ubyte[])null);
 			} else {
 				// TODO: remove after deprecation period
-				auto ret = () @trusted { return __traits(getMember, inst, Method)(params); } ();
-
-				static if (!__traits(compiles, () @safe { evaluateOutputModifiers!Func(ret, req, res); } ()))
+				static if (!__traits(compiles, () @safe { evaluateOutputModifiers!Func(RT.init, req, res); } ()))
 					pragma(msg, "Non-@safe @after evaluators are deprecated - annotate @after evaluator function for " ~
 						T.stringof ~ "." ~ Method ~ " as @safe.");
 
-				ret = () @trusted { return evaluateOutputModifiers!CFunc(ret, req, res); } ();
+				auto ret = () @trusted {
+					return evaluateOutputModifiers!CFunc(
+						__traits(getMember, inst, Method)(params), req, res); } ();
 				returnHeaders();
 
 				string accept_str;


### PR DESCRIPTION
If the return value of the functioin is const,
trying to re-assiign 'ret' will throw an error inside vibe.d.
Since the only purpose of this separation was for a deprecation message
inside a __traits(compiles), we just use RT.init to give it the correct type,
and merge the two lambdas together.