### PR TITLE
Fix #2521: Do not require Content-Type for void return type

### DIFF
--- a/tests/vibe.web.rest.2521/dub.json
+++ b/tests/vibe.web.rest.2521/dub.json
@@ -1,0 +1,6 @@
+{
+    "name": "2521",
+    "dependencies": {
+        "vibe-d": { "path": "../../" }
+    }
+}

--- a/tests/vibe.web.rest.2521/source/app.d
+++ b/tests/vibe.web.rest.2521/source/app.d
@@ -1,0 +1,48 @@
+import vibe.d;
+
+interface SimpleAPI
+{
+    @safe:
+
+    void postData(string data);
+
+    void postData2(@viaHeader("Content-Type") out string type, string data);
+}
+
+int main (string[] args)
+{
+    auto settings = new HTTPServerSettings;
+	settings.port = 0;
+	settings.bindAddresses = [ "127.0.0.1" ];
+	auto router = new URLRouter;
+    router.post("/data", &handlePostData);
+    router.post("/data2", &handlePostData2);
+    auto listener = listenHTTP(settings, router);
+	runTask(&doTest, listener.bindAddresses[0]);
+
+    return runApplication(&args);
+}
+
+void handlePostData (scope HTTPServerRequest req, scope HTTPServerResponse res)
+    @safe
+{
+    res.writeVoidBody();
+}
+
+void handlePostData2 (scope HTTPServerRequest req, scope HTTPServerResponse res)
+    @safe
+{
+    res.headers["Content-Type"] = "text/html; charset=UTF-8";
+    res.writeVoidBody();
+}
+
+void doTest (immutable NetworkAddress address)
+{
+    scope (exit) exitEventLoop();
+
+    string result;
+    scope client = new RestInterfaceClient!SimpleAPI("http://" ~ address.toString());
+    client.postData("Hello");
+    client.postData2(result, "World");
+    assert(result == "text/html; charset=UTF-8");
+}


### PR DESCRIPTION
```
While the server SHOULD provide Content-Type if it returns data,
it will most likely not if it doesn't return anything.
In this case, we treat it as application/octet-stream,
as prescribed by RFC 2616, section 7.2.1.
```

~Still testing locally, don't merge yet.~ Works