### PR TITLE
Add a workkflow to test Musl compatibility

### DIFF
--- a/.github/workflows/musl.yml
+++ b/.github/workflows/musl.yml
@@ -1,0 +1,30 @@
+name: Musl tests
+
+on:
+  pull_request:
+    branches:
+      - master
+  push:
+    branches:
+      - master
+      - github_actions
+
+jobs:
+  main:
+    name: Musl tests
+    strategy:
+      fail-fast: false
+      matrix:
+        dc: [ dmd, ldc ]
+        include:
+          - { dc: dmd, dcname: dmd  }
+          - { dc: ldc, dcname: ldc2 }
+    runs-on: ubuntu-latest
+    container: alpine
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install dependencies
+        run: apk add --no-cache build-base dub ${{ matrix.dc }} openssl-dev zlib-dev
+      - name: Run tests
+        run: dub test --compiler=${{ matrix.dcname }}

--- a/run-ci.sh
+++ b/run-ci.sh
@@ -92,7 +92,7 @@ if [[ $PARTS =~ (^|,)mongo(,|$) ]]; then
 
             kill $MONGOPID
 
-            while kill -0 $MONGOPID; do 
+            while kill -0 $MONGOPID; do
                 sleep 1
             done
         fi

--- a/run-ci.sh
+++ b/run-ci.sh
@@ -111,15 +111,6 @@ if [[ $PARTS =~ (^|,)meson(,|$) ]]; then
         # as soon as the bug is fixed, we can run tests again for the fixed LDC versions.
         allow_meson_test="no"
     fi
-    if [[ ${DC=dmd} = dmd ]]; then
-        dc_version=$("$DC" --version | perl -pe '($_)=/([0-9]+([.][0-9]+)+)/')
-        if [[ ${dc_version} = "2.072.2" ]]; then
-            # The stream test fails with DMD 2.072.2 due to a missing symbol. This is a DMD bug,
-            # so we skip tests here.
-            # This check can be removed when support for that compiler version is dropped.
-            allow_meson_test="no"
-        fi
-    fi
 
     # we limit the number of Ninja jobs to 4, so GitHub Actions doesn't kill us
     ninja -j4


### PR DESCRIPTION
This is currently a copy of what's done in vibe-core, however vibe.d tests are a bit more complex and the basic `dub test` is not that useful.