### PR TITLE
Fix "web-auth" example for `Nullable` `alias get this` removal.

### DIFF
--- a/examples/web-auth/views/home.dt
+++ b/examples/web-auth/views/home.dt
@@ -6,13 +6,13 @@ block head
 block contents
 
 	- if (!auth.isNull)
-		p Hello, #{auth.userName}! Welcome to your personal web service.
+		p Hello, #{auth.get.userName}! Welcome to your personal web service.
 
 		p You can <a href="settings">edit settings</a>.
 
-		p Currently your <a href="premium">premium membership</a> is #{auth.isPremiumUser ? "on" : "off"}.
+		p Currently your <a href="premium">premium membership</a> is #{auth.get.isPremiumUser ? "on" : "off"}.
 
-		- if (auth.isAdmin)
+		- if (auth.get.isAdmin)
 			p View the <a href="admin"> admin panel </a>
 	- else
 		p This is an example web service.


### PR DESCRIPTION
Assuming buildkite checks the example folders alphabetically, this should be the last one?