### PR TITLE
Respect keep-alive on client requests

### DIFF
--- a/http/vibe/http/client.d
+++ b/http/vibe/http/client.d
@@ -608,7 +608,7 @@ final class HTTPClient {
 
 	private bool doRequestWithRetry(scope void delegate(HTTPClientRequest req) requester, bool confirmed_proxy_auth /* basic only */, out bool close_conn, out SysTime connected_time)
 	{
-		if (m_conn && m_conn.connected && connected_time > m_keepAliveLimit){
+		if (m_conn && m_conn.connected && Clock.currTime(UTC()) > m_keepAliveLimit){
 			logDebug("Disconnected to avoid timeout");
 			disconnect();
 		}


### PR DESCRIPTION
`m_keepAliveLimit` must be compared to the current time.
`connected_time` is an `out` parameter that shouldn't be read before being initialized.

This bug was introduced in https://github.com/vibe-d/vibe.d/commit/560290a6bfc26a20e824a0c4808e32c4911b3f6c.