### PR TITLE
Work around 9423 by explicitly providing 'in' on delegates

### DIFF
--- a/http/vibe/http/server.d
+++ b/http/vibe/http/server.d
@@ -412,10 +412,10 @@ struct DefaultDietFilters {
 
 	static this()
 	{
-		filters["css"] = (input, scope output) { output(filterCss(input)); };
-		filters["javascript"] = (input, scope output) { output(filterJavascript(input)); };
-		filters["markdown"] = (input, scope output) { output(filterMarkdown(() @trusted { return cast(string)input; } ())); };
-		filters["htmlescape"] = (input, scope output) { output(filterHtmlescape(input)); };
+		filters["css"] = (in input, scope output) { output(filterCss(input)); };
+		filters["javascript"] = (in input, scope output) { output(filterJavascript(input)); };
+		filters["markdown"] = (in input, scope output) { output(filterMarkdown(() @trusted { return cast(string)input; } ())); };
+		filters["htmlescape"] = (in input, scope output) { output(filterHtmlescape(input)); };
 	}
 
 	static SafeFilterCallback[string] filters;

--- a/tls/vibe/stream/openssl.d
+++ b/tls/vibe/stream/openssl.d
@@ -1136,12 +1136,12 @@ private bool verifyCertName(X509* cert, int field, in char[] value, bool allow_w
 		case GENERAL_NAME.GEN_DNS:
 			cnid = NID_commonName;
 			alt_type = V_ASN1_IA5STRING;
-			str_match = allow_wildcards ? s => matchWildcard(value, s) : s => s.icmp(value) == 0;
+			str_match = allow_wildcards ? (in s) => matchWildcard(value, s) : (in s) => s.icmp(value) == 0;
 			break;
 		case GENERAL_NAME.GEN_IPADD:
 			cnid = 0;
 			alt_type = V_ASN1_OCTET_STRING;
-			str_match = s => s == value;
+			str_match = (in s) => s == value;
 			break;
 	}
 


### PR DESCRIPTION
Due to issue 9423, storage classes such as 'ref', 'in', and 'out'
are not inferred on delegate literals.
'scope' wasn't infered either, but due to the changes for DIP1000
ends up sometimes being infered.