### PR TITLE
Fix file example

### DIFF
--- a/examples/file_operations/dub.json
+++ b/examples/file_operations/dub.json
@@ -4,5 +4,4 @@
 	"dependencies": {
 		"vibe-d:core": {"path": "../../"}
 	},
-	"versions": ["VibeDefaultMain"]
 }

--- a/examples/file_operations/source/app.d
+++ b/examples/file_operations/source/app.d
@@ -7,47 +7,40 @@ static if (__VERSION__ >= 2076)
 else
 	import std.datetime;
 
-auto peekMSecs(T)(T sw)
-{
-static if (__VERSION__ >= 2076)
-	return sw.peek.total!"msecs";
-else
-	return sw.peek.msecs;
+auto peekMSecs(T)(T sw) {
+	static if (__VERSION__ >= 2076)
+		return sw.peek.total!"msecs";
+	else
+		return sw.peek.msecs;
 }
 
-shared static this()
-{
+void main() {
 	FileStream fs = openFile("./hello.txt", FileMode.createTrunc);
 	StopWatch sw;
 	sw.start();
 	bool finished;
 	auto task = runTask({
-		void print(ulong pos, size_t sz) {
-			auto off = fs.tell();
-			fs.seek(pos);
-			ubyte[] dst = new ubyte[sz];
-			fs.read(dst);
-			writefln("%s", cast(string)dst);
-			fs.seek(off);
-		}
 		writeln("Task 1: Starting write operations to hello.txt");
-		while(sw.peekMSecs < 150) {
+		while (sw.peekMSecs < 150) {
 			fs.write("Some string is being written here ..");
 		}
-		writeln("Task 1: Final offset: ", fs.tell(), "B, file size: ", fs.size(), "B", ", total time: ", sw.peekMSecs, " ms");
+		writeln("Task 1: Final offset: ", fs.tell(), "B, file size: ",
+			fs.size(), "B", ", total time: ", sw.peekMSecs, " ms");
 		fs.close();
 		finished = true;
 	});
 
 	runTask({
-		while(!finished)
-		{
+		while (!finished) {
 			writeln("Task 2: Task 1 has written ", fs.size(), "B so far in ", sw.peekMSecs, " ms");
 			sleep(10.msecs);
 		}
 		removeFile("./hello.txt");
-		writeln("Task 2: Done. Press CTRL+C to exit.");
+		writeln("Task 2: Done.");
 		sw.stop();
+		exitEventLoop();
 	});
 	writeln("Main Thread: Writing small chunks in a yielding task (Task 1) for 150 ms");
+
+	runApplication();
 }


### PR DESCRIPTION
Debugging showed that the FileStream is destructed as soon as main is
exited (the task are running later). Interestingly, the bool can be
captured in the closure, but this seems not to work with the refcounted
FileStream. Passing the FileStream explicitely to the task as argument
solves that.

Unfortunately this is counter intuitive, as both bool and FileStream are
value types and we need to handle one differently from the other.

Fixes #2547


p.s. i also ran the app.d through dfmt (with defaults). If thats a problem
I am happy to do another patch without the formatting.
