### PR TITLE
Websockets: make FrameOpcode public

### DIFF
--- a/http/vibe/http/websockets.d
+++ b/http/vibe/http/websockets.d
@@ -1042,7 +1042,7 @@ private static immutable s_webSocketGuid = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11
  * Currently only 6 values are defined, however the opcode is defined as
  * taking 4 bits.
  */
-private enum FrameOpcode : ubyte {
+public enum FrameOpcode : ubyte {
 	continuation = 0x0,
 	text = 0x1,
 	binary = 0x2,


### PR DESCRIPTION
It's part of the public API of IncomingWebSocketMessage and should be available as well.

https://vibed.org/api/vibe.http.websockets/IncomingWebSocketMessage