### PR TITLE
Fix HTTP content.length header for content-ranges responses.

### DIFF
--- a/http/vibe/http/fileserver.d
+++ b/http/vibe/http/fileserver.d
@@ -320,7 +320,7 @@ private void sendFileImpl(scope HTTPServerRequest req, scope HTTPServerResponse 
 		range = parseRangeHeader(*prange, dirent.size, res);
 
 		// potential integer overflow with rangeEnd - rangeStart == size_t.max is intended. This only happens with empty files, the + 1 will then put it back to 0
-		res.headers["Content-Length"] = to!string(range.min - range.max);
+		res.headers["Content-Length"] = to!string(range.max - range.min);
 		res.headers["Content-Range"] = "bytes %s-%s/%s".format(range.min, range.max - 1, dirent.size);
 		res.statusCode = HTTPStatus.partialContent;
 	} else res.headers["Content-Length"] = dirent.size.to!string;

--- a/http/vibe/http/server.d
+++ b/http/vibe/http/server.d
@@ -1711,7 +1711,7 @@ final class HTTPServerResponse : HTTPResponse {
 		if (m_rawConnection && m_rawConnection.connected) {
 			try if (m_conn) m_conn.flush();
 			catch (Exception e) logDebug("Failed to flush connection after finishing HTTP response: %s", e.msg);
-			if (!isHeadResponse && bytesWritten < headers.get("Content-Length", "0").to!long) {
+			if (!isHeadResponse && bytesWritten < headers.get("Content-Length", "0").to!ulong) {
 				logDebug("HTTP response only written partially before finalization. Terminating connection.");
 				m_requiresConnectionClose = true;
 			}


### PR DESCRIPTION
Also fixes a bogus secondary exception caused by attempting to parse ulong.max as long.