### PR TITLE
Avoid using closures in REST router

### DIFF
--- a/examples/rest-collections/source/api.d
+++ b/examples/rest-collections/source/api.d
@@ -5,6 +5,7 @@ import vibe.web.rest;
 
 interface ForumAPI {
 	// base path /threads/
+@safe:
 	Collection!ThreadAPI threads();
 }
 
@@ -14,6 +15,7 @@ interface ThreadAPI {
 		string _thread_name;
 	}
 
+@safe:
 	// base path /threads/:thread_number/posts/
 	Collection!PostAPI posts(string _thread_name);
 
@@ -33,6 +35,7 @@ interface PostAPI {
 		int _post_index;
 	}
 
+@safe:
 	// POST /threads/:thread_number/posts/
 	// Posts a new thread reply
 	void post(string _thread_name, string message);

--- a/examples/rest-collections/source/app.d
+++ b/examples/rest-collections/source/app.d
@@ -23,7 +23,7 @@ class LocalForumAPI : ForumAPI {
 		m_data = new ForumData;
 		m_threads = new LocalThreadAPI(m_data);
 	}
-
+@safe:
 	Collection!ThreadAPI threads() { return Collection!ThreadAPI(m_threads); }
 }
 
@@ -33,6 +33,7 @@ class LocalThreadAPI : ThreadAPI {
 		LocalPostAPI m_posts;
 	}
 
+@safe:
 	this(ForumData data)
 	{
 		m_data = data;
@@ -48,7 +49,7 @@ class LocalThreadAPI : ThreadAPI {
 
 	string[] get()
 	{
-		return m_data.threads.keys;
+		return () @trusted { return m_data.threads.keys; } ();
 	}
 }
 
@@ -57,6 +58,7 @@ class LocalPostAPI : PostAPI {
 		ForumData m_data;
 	}
 
+@safe:
 	this(ForumData data)
 	{
 		m_data = data;

--- a/examples/rest-js/source/app.d
+++ b/examples/rest-js/source/app.d
@@ -3,6 +3,7 @@ import vibe.http.common : HTTPMethod;
 
 // Defines a simple RESTful API
 interface ITest {
+@safe:
 	// GET /compute_sum?a=...&b=...
 	@method(HTTPMethod.GET)
 	float computeSum(float a, float b);
@@ -14,6 +15,7 @@ interface ITest {
 // Local implementation that will be provided by the server
 class Test : ITest {
 	import std.stdio;
+@safe:
 	float computeSum(float a, float b) { return a + b; }
 	void postToConsole(string text) { writeln(text); }
 }

--- a/tests/restclient/source/app.d
+++ b/tests/restclient/source/app.d
@@ -6,6 +6,7 @@ interface ITestAPI
 {
 	@property ISub sub();
 
+@safe:
 	@method(HTTPMethod.POST) @path("other/path")
 	string info();
 	string getInfo();
@@ -22,6 +23,7 @@ interface ITestAPI
 }
 
 interface ISub {
+@safe:
 	int get(int id);
 }
 
@@ -31,6 +33,7 @@ class TestAPI : ITestAPI
 
 	this() { m_sub = new SubAPI; }
 
+@safe:
 	@property SubAPI sub() { return m_sub; }
 
 	string getInfo() { return "description"; }
@@ -49,6 +52,7 @@ class SubAPI : ISub {
 
 interface ITestAPICors
 {
+@safe:
 	string getFoo();
 	string setFoo();
 	string addFoo();
@@ -62,6 +66,7 @@ interface ITestAPICors
 
 class TestAPICors : ITestAPICors
 {
+@safe:
 	string getFoo() { return "foo"; };
 	string setFoo() { return "foo"; };
 	string addFoo() { return "foo"; };

--- a/tests/restcollections/source/app.d
+++ b/tests/restcollections/source/app.d
@@ -3,6 +3,7 @@ module app;
 import vibe.vibe;
 
 interface API {
+@safe:
 	Collection!ItemAPI items();
 }
 
@@ -11,6 +12,7 @@ interface ItemAPI {
 		string _item;
 	}
 
+@safe:
 	Collection!SubItemAPI subItems(string _item);
 
 	ItemManagerAPI manager();
@@ -22,6 +24,7 @@ interface SubItemAPI {
 		int _index;
 	}
 
+@safe:
 	@property int length(string _item);
 
 	@method(HTTPMethod.GET)
@@ -29,12 +32,14 @@ interface SubItemAPI {
 }
 
 interface ItemManagerAPI {
+@safe:
 	@property string databaseURL();
 }
 
 
 class LocalAPI : API {
 	LocalItemAPI m_items;
+@safe:
 	this() { m_items = new LocalItemAPI; }
 	Collection!ItemAPI items() { return Collection!ItemAPI(m_items); }
 }
@@ -45,6 +50,7 @@ class LocalItemAPI : ItemAPI {
 		LocalSubItemAPI m_subItems;
 	}
 
+@safe:
 	this()
 	{
 		m_manager = new LocalItemManagerAPI;
@@ -59,6 +65,7 @@ class LocalItemAPI : ItemAPI {
 class LocalSubItemAPI : SubItemAPI {
 	private LocalItemManagerAPI m_manager;
 
+@safe:
 	this(LocalItemManagerAPI manager)
 	{
 		m_manager = manager;
@@ -72,6 +79,7 @@ class LocalSubItemAPI : SubItemAPI {
 class LocalItemManagerAPI : ItemManagerAPI {
 	string[][string] items;
 
+@safe:
 	this()
 	{
 		items = [

--- a/tests/vibe.web.rest.1125/source/app.d
+++ b/tests/vibe.web.rest.1125/source/app.d
@@ -21,11 +21,13 @@ shared static this()
 }
 
 interface ILlama {
+@safe:
     @bodyParam("llama", "llama")
     string updateLlama(string llama = null);
 }
 
 class Llama : ILlama {
+@safe:
     string updateLlama(string llama) {
         assert(llama == "llama", "[vibe.web.rest.1125.Server] Expected llama, got: " ~ llama);
         return llama;

--- a/tests/vibe.web.rest.1140/source/app.d
+++ b/tests/vibe.web.rest.1140/source/app.d
@@ -3,11 +3,13 @@ import vibe.d;
 
 interface IOrientDBRoot
 {
+@safe:
 	@property IOrientDBQuery query();
 }
 
 interface IOrientDBQuery
 {
+@safe:
 	@method(HTTPMethod.GET)
 	@path(":db_name/sql/:query/:result_set_size")
 	Json sql(string _db_name, string _query, int _result_set_size);
@@ -19,11 +21,13 @@ interface IOrientDBQuery
 
 class OrientDBRoot : IOrientDBRoot {
 	private OrientDBQuery m_query;
+@safe:
 	override @property IOrientDBQuery query() { return m_query; }
 	public this() { this.m_query = new OrientDBQuery(); }
 }
 
 class OrientDBQuery : IOrientDBQuery {
+@safe:
 	override Json sql(string _db_name, string _query, int _result_set_size) {
 		assert(_db_name == Param1, _db_name);
 		assert(_query == Param2, _query);

--- a/tests/vibe.web.rest.1230/source/app.d
+++ b/tests/vibe.web.rest.1230/source/app.d
@@ -2,10 +2,12 @@ import std.datetime;
 import vibe.d;
 
 interface ITestAPI {
+@safe:
     string postDefault(int value, bool check = true);
 }
 
 class Test : ITestAPI {
+@safe:
     string postDefault(int value, bool check = true) {
         import std.format;
         return format("Value: %s, Check: %s", value, check);

--- a/tests/vibe.web.rest.1922/source/app.d
+++ b/tests/vibe.web.rest.1922/source/app.d
@@ -46,6 +46,7 @@ interface IItemAPI {
 		string item;
 	}
 
+@safe:
 	@anyAuth string getName(string item, AuthInfo info);
 	@anyAuth int getNum(int num);
 
@@ -53,6 +54,7 @@ interface IItemAPI {
 }
 
 class ItemAPI : IItemAPI {
+@safe:
 	string getName(string item, AuthInfo info){
 		return info.name ~ item;
 	}
@@ -64,6 +66,7 @@ class ItemAPI : IItemAPI {
 
 @requiresAuth
 interface IAuthAPI {
+@safe:
 	@noAuth int getNonAuthNumber(int num);
 	@anyAuth int getAuthNumber(AuthInfo info, int num);
 	@anyAuth Collection!IItemAPI items();
@@ -73,6 +76,7 @@ interface IAuthAPI {
 
 class AuthAPI : IAuthAPI {
 	private IItemAPI m_items;
+@safe:
 	this(){
 		m_items = new ItemAPI;
 	}

--- a/tests/vibe.web.rest.auth/source/app.d
+++ b/tests/vibe.web.rest.auth/source/app.d
@@ -71,6 +71,7 @@ struct Auth {
 
 @requiresAuth
 interface IService {
+@safe:
     @noAuth int getPublic();
     @anyAuth int getAny();
     @anyAuth int getAnyA(Auth auth);
@@ -82,6 +83,7 @@ interface IService {
 }
 
 class Service : IService {
+@safe:
     int getPublic() { return 42; }
     int getAny() { return 42; }
     int getAnyA(Auth auth) { assert(auth.username.among("admin", "peter", "stacy")); return 42; }

--- a/web/vibe/web/rest.d
+++ b/web/vibe/web/rest.d
@@ -1624,7 +1624,7 @@ private HTTPServerRequestDelegate jsonMethodHandler(alias Func, size_t ridx, T)(
 
 			static if (is(RT == void)) {
 				// TODO: remove after deprecation period
-				() @trusted { __traits(getMember, inst, Method)(params); } ();
+				__traits(getMember, inst, Method)(params);
 				returnHeaders();
 				res.writeBody(cast(ubyte[])null);
 			} else {
@@ -1633,9 +1633,8 @@ private HTTPServerRequestDelegate jsonMethodHandler(alias Func, size_t ridx, T)(
 					pragma(msg, "Non-@safe @after evaluators are deprecated - annotate @after evaluator function for " ~
 						T.stringof ~ "." ~ Method ~ " as @safe.");
 
-				auto ret = () @trusted {
-					return evaluateOutputModifiers!CFunc(
-						__traits(getMember, inst, Method)(params), req, res); } ();
+				auto ret = evaluateOutputModifiers!CFunc(
+						__traits(getMember, inst, Method)(params), req, res);
 				returnHeaders();
 
 				string accept_str;


### PR DESCRIPTION
This came up while trying to add explicit dtors to one of our API arguments.
Removing trusted dgs didn't cause any problems, for our application at least.