### PR TITLE
CI: Update supported compiler

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,12 +10,22 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu-latest ]
-        dc: [ dmd-latest, dmd-2.094.2, dmd-2.089.1, dmd-2.084.1, ldc-1.24.0, ldc-1.21.0, ldc-1.17.0 ]
+        dc:
+          - dmd-latest
+          - dmd-2.096.1
+          - dmd-2.095.1
+          - dmd-2.092.1
+          - dmd-2.087.1
+          - ldc-latest
+          - ldc-1.26.0
+          - ldc-1.25.0
+          - ldc-1.22.0
+          - ldc-1.17.0
         include:
           # Default
           - { parts: 'builds,unittests,examples,tests,mongo', extra_dflags: '' }
           # Custom part for coverage
-          - { dc: dmd-2.094.2, parts: 'unittests,tests', extra_dflags: "-cov -version=VibedSetCoverageMerge" }
+          - { dc: dmd-latest, parts: 'unittests,tests', extra_dflags: "-cov -version=VibedSetCoverageMerge" }
 
     runs-on: ${{ matrix.os }}
     timeout-minutes: 60


### PR DESCRIPTION
Change 'every 5 releases' to 'last 4 releases then every 5 releases',
as it is most likely that users are stuck one or two version back.
Currently assumes that ldc-latest is v1.27.0, which is yet to be released,
but should be soon.