### PR TITLE
Set SSL_OP_NO_TLSv1_3 always, since vibe.d does not support

### DIFF
--- a/tls/vibe/stream/openssl.d
+++ b/tls/vibe/stream/openssl.d
@@ -631,7 +631,7 @@ final class OpenSSLContext : TLSContext {
 						break;
 					case TLSVersion.ssl3:
 						method = SSLv23_client_method();
-						options |= SSL_OP_NO_SSLv2|SSL_OP_NO_TLSv1_1|SSL_OP_NO_TLSv1|SSL_OP_NO_TLSv1_2;
+						options |= SSL_OP_NO_TLSv1_1|SSL_OP_NO_TLSv1|SSL_OP_NO_TLSv1_2;
 						break;
 					case TLSVersion.tls1:
 						method = TLSv1_client_method();
@@ -661,7 +661,7 @@ final class OpenSSLContext : TLSContext {
 						break;
 					case TLSVersion.ssl3:
 						method = SSLv23_server_method();
-						options |= SSL_OP_NO_SSLv2|SSL_OP_NO_TLSv1_1|SSL_OP_NO_TLSv1|SSL_OP_NO_TLSv1_2;
+						options |= SSL_OP_NO_TLSv1_1|SSL_OP_NO_TLSv1|SSL_OP_NO_TLSv1_2;
 						break;
 					case TLSVersion.tls1:
 						method = TLSv1_server_method();

--- a/tls/vibe/stream/openssl.d
+++ b/tls/vibe/stream/openssl.d
@@ -132,16 +132,6 @@ static if (OPENSSL_VERSION.startsWith("1.1")) {
 		extern(C) void* sk_value(const(_STACK)* p, int i) { return OPENSSL_sk_value(p, i); }
 	}
 
-	private enum SSL_CTRL_SET_MIN_PROTO_VERSION = 123;
-
-	private int SSL_CTX_set_min_proto_version(ssl_ctx_st* ctx, int ver) {
-		return cast(int) SSL_CTX_ctrl(ctx, SSL_CTRL_SET_MIN_PROTO_VERSION, ver, null);
-	}
-
-	private int SSL_set_min_proto_version(ssl_st* s, int ver) {
-		return cast(int) SSL_ctrl(s, SSL_CTRL_SET_MIN_PROTO_VERSION, ver, null);
-	}
-
 	extern(C) nothrow {
 		void BIO_set_init(BIO* bio, int init_) @trusted;
 		int BIO_get_init(BIO* bio) @trusted;


### PR DESCRIPTION
* Add SSL_OP_NO_TLSv1_3 and use everywhere if OpenSSL >= 1.1.1 used.
* Set SSL_OP_ALL for some bug workarounds.
* Drop verption logic, since which accidentaly ignores SSL_OP_NO_SSL/TLS options.