### PR TITLE
Meson: fixes using vibe.d as subproject

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -35,15 +35,13 @@ endif
 
 if meson.is_subproject() == false
     if meson.get_compiler('d').get_id() == 'llvm'
-        add_global_arguments(['-d-version=VibeLibeventDriver',
-                              '-d-version=Have_openssl',
+        add_global_arguments(['-d-version=Have_openssl',
                               '-d-version=Have_diet_ng',
                               '-d-version=Have_stdx_allocator',
                               flag_new_openssl_ldc], language : 'd')
     endif
     if meson.get_compiler('d').get_id() == 'dmd'
-        add_global_arguments(['-version=VibeLibeventDriver',
-                              '-version=Have_openssl',
+        add_global_arguments(['-version=Have_openssl',
                               '-version=Have_diet_ng',
                               '-version=Have_stdx_allocator',
                               flag_new_openssl_dmd], language : 'd')

--- a/meson.build
+++ b/meson.build
@@ -33,20 +33,23 @@ if ssl_dep.version().version_compare('>=1.1')
     flag_new_openssl_dmd = '-version=VibeUseOpenSSL11'
 endif
 
-if meson.get_compiler('d').get_id() == 'llvm'
-    add_global_arguments(['-d-version=VibeLibeventDriver',
-                          '-d-version=Have_openssl',
-                          '-d-version=Have_diet_ng',
-                          '-d-version=Have_stdx_allocator',
-                          flag_new_openssl_ldc], language : 'd')
+if meson.is_subproject() == false
+    if meson.get_compiler('d').get_id() == 'llvm'
+        add_global_arguments(['-d-version=VibeLibeventDriver',
+                              '-d-version=Have_openssl',
+                              '-d-version=Have_diet_ng',
+                              '-d-version=Have_stdx_allocator',
+                              flag_new_openssl_ldc], language : 'd')
+    endif
+    if meson.get_compiler('d').get_id() == 'dmd'
+        add_global_arguments(['-version=VibeLibeventDriver',
+                              '-version=Have_openssl',
+                              '-version=Have_diet_ng',
+                              '-version=Have_stdx_allocator',
+                              flag_new_openssl_dmd], language : 'd')
+    endif
 endif
-if meson.get_compiler('d').get_id() == 'dmd'
-    add_global_arguments(['-version=VibeLibeventDriver',
-                          '-version=Have_openssl',
-                          '-version=Have_diet_ng',
-                          '-version=Have_stdx_allocator',
-                          flag_new_openssl_dmd], language : 'd')
-endif
+
 if meson.get_compiler('d').get_id() == 'gnu'
     error('Vibe.d can not be compiled with GDC at time (2016). Sorry.')
 endif


### PR DESCRIPTION
Fixes error of using vibe.d as subproject:

subprojects/vibe.d-0.9.3/meson.build:37:4: ERROR: Function 'add_global_arguments' cannot be used in subprojects because there is no way to make that reliable.
Please only call this if is_subproject() returns false. Alternatively, define a variable that
contains your language-specific arguments and add it to the appropriate *_args kwarg in each target.
