### PR TITLE
Do not set `SSL_OP_NO_COMPRESSION` for OpenSSL v1.1.0

### DIFF
--- a/tls/vibe/stream/openssl.d
+++ b/tls/vibe/stream/openssl.d
@@ -608,11 +608,17 @@ final class OpenSSLContext : TLSContext {
 		m_kind = kind;
 
 		const(SSL_METHOD)* method;
+
 		c_ulong veroptions = SSL_OP_NO_SSLv2;
-		c_ulong options = SSL_OP_NO_COMPRESSION;
-		static if (OPENSSL_VERSION.startsWith("1.1")) {}
-		else
-			options |= SSL_OP_SINGLE_DH_USE|SSL_OP_SINGLE_ECDH_USE; // There are always enabled in OpenSSL 1.1.0.
+		c_ulong options;
+		static if (!OPENSSL_VERSION.startsWith("1.1"))
+		{
+			// TODO: Make this more foolproof, as we now assume either 1.0 or 1.1
+			// These options are always enabled in OpenSSL 1.1.0
+			// They are mitigation techniques against some attacks,
+			// e.g. `SSL_OP_NO_COMPRESSION` is a countermeasure for `CRIME` attacks
+			options |= SSL_OP_NO_COMPRESSION|SSL_OP_SINGLE_DH_USE|SSL_OP_SINGLE_ECDH_USE;
+		}
 		int minver = TLS1_VERSION;
 		int maxver = TLS1_2_VERSION;
 


### PR DESCRIPTION
Our project was seeing a bunch of those messages:
```
Aug 05 06:28:41 eu-002 docker[1211216]: SSL modified options: passed 0x00020000 vs applied 0x00000000
Aug 05 06:28:41 eu-002 docker[1211216]: SSL modified options: passed 0x00020000 vs applied 0x00000000
Aug 05 06:28:41 eu-002 docker[1211216]: SSL modified options: passed 0x00020000 vs applied 0x00000000
Aug 05 06:28:41 eu-002 docker[1211216]: SSL modified options: passed 0x00020000 vs applied 0x00000000
Aug 05 06:28:41 eu-002 docker[1211216]: SSL modified options: passed 0x00020000 vs applied 0x00000000
```

The message originates from a `logDiagnotic`:
https://github.com/vibe-d/vibe.d/blob/1f830a8241041c39c61bbdcde37fe4bc40c13432/tls/vibe/stream/openssl.d#L652-L662

The `0x00020000` matches [`SSL_OP_NO_COMPRESSION`](https://github.com/D-Programming-Deimos/openssl/blob/fc5b9b1847f105397c59e5a3a17ecfded22001d9/deimos/openssl/ssl.d#L595-L596)
which was set unconditionally for any version:
https://github.com/vibe-d/vibe.d/blob/1f830a8241041c39c61bbdcde37fe4bc40c13432/tls/vibe/stream/openssl.d#L610

This was introduced in 2014 (v0.7.20): https://github.com/vibe-d/vibe.d/commit/da7824023823dd02adad9fa6bd3aa5941b1d9126#diff-a29cebbd0dab20a328e647a455ceefd848dbbc1921dc12a4c9316df4e890df99R451

However, compression [is off by default as of OpenSSL v1.1.0](https://www.openssl.org/docs/man1.1.0/man3/SSL_CONF_cmd_value_type.html).
This option was originally put in place to mitigate [CRIME attacks](https://en.wikipedia.org/wiki/CRIME)
according to [this source](https://python-security.readthedocs.io/ssl.html).

Applying the same fix as the other options will prevent downstream code from seeing spurious messages like this.