### PR TITLE
Fix secret length mismatch at digest auth

### DIFF
--- a/http/vibe/http/auth/digest_auth.d
+++ b/http/vibe/http/auth/digest_auth.d
@@ -29,7 +29,7 @@ class DigestAuthInfo
 	@safe:
 
 	string realm;
-	ubyte[32] secret;
+	ubyte[16] secret;
 	ulong timeout;
 
 	this()


### PR DESCRIPTION
This fixes https://github.com/vibe-d/vibe.d/issues/2597.
It has been broken after https://github.com/vibe-d/vibe.d/commit/0046c48bd8d85fe68fd07b1fa94ddabaf57e2f13 was committed.
This also fixes the expiration logic bug.