### PR TITLE
AWS DocumentDB support through OP_MSG and handling different OK type

### DIFF
--- a/mongodb/vibe/db/mongo/cursor.d
+++ b/mongodb/vibe/db/mongo/cursor.d
@@ -12,8 +12,8 @@ public import vibe.data.bson;
 import vibe.db.mongo.connection;
 import vibe.db.mongo.client;
 
-import std.array : array;
-import std.algorithm : map, max, min;
+import std.array : array, split;
+import std.algorithm : map, max, min, canFind, endsWith;
 import std.exception;
 
 deprecated alias MongoCursor(Q, R = Bson, S = Bson) = MongoCursor!R;
@@ -352,20 +352,26 @@ private class MongoFindCursor(Q, R, S) : MongoCursorData!R {
 			query = () @trusted { return serializeToBson(m_query, query_buf); } ();
 		}
 
-		Bson full_query;
+		Bson full_query = Bson.emptyObject;
 
-		if (!query["query"].isNull() || !query["$query"].isNull()) {
-			// TODO: emit deprecation warning
-			full_query = query;
+		string collection;
+		if (query["aggregate"].isNull && m_collection.canFind(".") && !m_collection.endsWith("$cmd")) {
+			collection = m_collection.split(".")[1];
 		} else {
-			full_query = Bson.emptyObject;
-			full_query["$query"] = query;
+			collection = m_collection;
+		}
+
+		if (query["aggregate"].isNull) {
+			full_query["find"] = Bson(collection);
+			full_query["filter"] = query;
+		} else {
+			full_query = query;
 		}
 
 		if (!m_sort.isNull()) full_query["orderby"] = m_sort;
 
-		conn.query!R(m_collection, m_flags, m_nskip, m_nret, full_query, selector, &handleReply, &handleDocument);
-
+		conn.query!R(collection, m_flags, m_nskip, m_nret, full_query, selector, &handleReply, &handleDocument, !query["aggregate"].isNull);
+		
 		m_iterationStarted = true;
 	}
 }


### PR DESCRIPTION
I wouldn't suggest merging this directly as is, as it could probably break compatibility with older mongodb <3.6 i believe is the cutoff here. But I thought i'd share the changes here as this was what I had to do to get vibe-d mongo driver to work with AWS DocumentDB. This is because even though docdb is mongo compliant it only has implemented OP_MSG for the operations i modified below. Also docdb doesn't support $external.$cmd for handshaking and so with this fork you MUST specify a database in the client settings so that it can auth against it.


I hope this can help you find a cleaner way to integrate these changes where they won't break non-docdb use cases. This was a quick and dirty way of getting compatibility working. 