### PR TITLE
Bump supported compiler version to v2.098.0 and dub to the modern age

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,15 +12,15 @@ jobs:
         os: [ ubuntu-latest ]
         dc:
           - dmd-latest
+          - dmd-2.097.1
           - dmd-2.096.1
-          - dmd-2.095.1
-          - dmd-2.092.1
-          - dmd-2.087.1
+          - dmd-2.093.1
+          - dmd-2.088.1
           - ldc-latest
+          - ldc-1.27.1
           - ldc-1.26.0
-          - ldc-1.25.0
-          - ldc-1.22.0
-          - ldc-1.17.0
+          - ldc-1.23.0
+          - ldc-1.18.0
         include:
           # Default
           - { parts: 'builds,unittests,examples,tests,mongo', extra_dflags: '' }

--- a/README.md
+++ b/README.md
@@ -116,15 +116,15 @@ Install vibe.d's dependencies:
 On 32-bit linux: Install DMD-i386
 
     sudo apt-get install g++ gcc-multilib xdg-utils
-    wget "http://downloads.dlang.org/releases/2.x/2.087.1/dmd_2.087.1-0_i386.deb"
-    sudo dpkg -i dmd_2.087.1-0_i386.deb
+    wget "http://downloads.dlang.org/releases/2.x/2.098.0/dmd_2.098.0-0_i386.deb"
+    sudo dpkg -i dmd_2.098.0-0_i386.deb
 
 
 On 64-bit linux: Install DMD-amd64
 
     sudo apt-get install g++ gcc-multilib xdg-utils
-    wget "http://downloads.dlang.org/releases/2.x/2.087.1/dmd_2.087.1-0_amd64.deb"
-    sudo dpkg -i dmd_2.087.1-0_amd64.deb
+    wget "http://downloads.dlang.org/releases/2.x/2.098.0/dmd_2.098.0-0_amd64.deb"
+    sudo dpkg -i dmd_2.098.0-0_amd64.deb
 
 
 Optionally, run `./setup-linux.sh` to create a user/group pair for privilege lowering.
@@ -135,7 +135,7 @@ Additional setup on Linux (generic)
 
 You need to have the following dependencies installed:
 
- - [DMD 2.077.1 or greater](http://dlang.org/download)
+ - [DMD 2.088.1 or greater](http://dlang.org/download)
  - [libssl](http://www.openssl.org/source/)
 
 Optionally, run `./setup-linux.sh` to create a user/group pair for privilege lowering.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,6 @@
 platform: x64
 environment:
+ dub_version: 1.7.2
  matrix:
   - DC: dmd
     DVersion: 2.098.0
@@ -79,7 +80,7 @@ install:
             }
         }
   - ps: SetUpDCompiler
-  - powershell -Command [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; Invoke-WebRequest "https://github.com/dlang/dub/releases/download/v1.7.2/dub-1.7.2-windows-x86.zip" -OutFile dub.zip
+  - powershell -Command [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; Invoke-WebRequest "https://github.com/dlang/dub/releases/download/v$($env:dub_version)/dub-$($env:dub_version)-windows-x86.zip" -OutFile dub.zip
   - 7z x dub.zip -odub > nul
   - set PATH=%CD%\%binpath%;%CD%\dub;%PATH%
   - dub --version

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -72,18 +72,10 @@ install:
               }
               $env:toolchain = "msvc";
               $version = $env:DVersion;
-              if($version -eq "1.3.0" -Or $version -eq "1.4.0" -Or $version -eq "1.5.0" -Or $version -eq "1.6.0") {
-                Invoke-WebRequest "https://github.com/ldc-developers/ldc/releases/download/v$($version)/ldc2-$($version)-win64-msvc.zip" -OutFile "c:\ldc.zip";
-                echo "finished.";
-                pushd c:\\;
-                7z x ldc.zip > $null;
-                popd;
-              } else {
-                Invoke-WebRequest "https://github.com/ldc-developers/ldc/releases/download/v$($version)/ldc2-$($version)-windows-$($env:arch).7z" -OutFile "c:\ldc.7z";
-                pushd c:\\;
-                7z x ldc.7z > $null;
-                popd;
-              }
+              Invoke-WebRequest "https://github.com/ldc-developers/ldc/releases/download/v$($version)/ldc2-$($version)-windows-$($env:arch).7z" -OutFile "c:\ldc.7z";
+              pushd c:\\;
+              7z x ldc.7z > $null;
+              popd;
             }
         }
   - ps: SetUpDCompiler
@@ -110,11 +102,7 @@ before_build:
          }
          elseif($env:DC -eq "ldc"){
            $version = $env:DVersion;
-           if($version -eq "1.3.0" -Or $version -eq "1.4.0" -Or $version -eq "1.5.0" -Or $version -eq "1.6.0") {
-               $env:PATH += ";C:\ldc2-$($version)-win64-msvc\bin";
-           } else {
-               $env:PATH += ";C:\ldc2-$($version)-windows-$($env:arch)\bin";
-           }
+           $env:PATH += ";C:\ldc2-$($version)-windows-$($env:arch)\bin";
            $env:DC = "ldc2";
          }
   - ps: $env:compilersetup = "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall";

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,37 +2,37 @@ platform: x64
 environment:
  matrix:
   - DC: dmd
-    DVersion: 2.096.1
+    DVersion: 2.098.0
     arch: x64
   - DC: dmd
-    DVersion: 2.096.1
+    DVersion: 2.098.0
+    arch: x86_mscoff
+  - DC: dmd
+    DVersion: 2.092.1
+    arch: x64
+  - DC: dmd
+    DVersion: 2.091.1
     arch: x86_mscoff
   - DC: dmd
     DVersion: 2.090.1
     arch: x64
   - DC: dmd
-    DVersion: 2.089.1
-    arch: x86_mscoff
-  - DC: dmd
     DVersion: 2.088.1
-    arch: x64
-  - DC: dmd
-    DVersion: 2.086.1
     arch: x86_mscoff
   - DC: ldc
-    DVersion: 1.26.0
+    DVersion: 1.28.0
     arch: x86
+  - DC: ldc
+    DVersion: 1.21.0
+    arch: x86
+  - DC: ldc
+    DVersion: 1.20.0
+    arch: x64
   - DC: ldc
     DVersion: 1.19.0
     arch: x86
   - DC: ldc
     DVersion: 1.18.0
-    arch: x64
-  - DC: ldc
-    DVersion: 1.17.0
-    arch: x86
-  - DC: ldc
-    DVersion: 1.16.0
     arch: x86
 
 branches:


### PR DESCRIPTION
If this works on the first try I'm going to buy a lotto ticket.
Main motivation, aside from the recent release of LDC v1.28.0, is to allow using `map` with `private` function, something not possible with v2.086 based frontend as there's a nasty visibility bug.