### PR TITLE
Update cryptorand.d - add a compile-time check

### DIFF
--- a/crypto/vibe/crypto/cryptorand.d
+++ b/crypto/vibe/crypto/cryptorand.d
@@ -556,7 +556,7 @@ unittest
 				assert(rand != prevRadn, "it's almost unbelievable - current and previous random bytes are equal");
 
 				//make sure that we have different random bytes in different hash digests
-				if(bufferSize > digestLength!Hash)
+				static if(bufferSize > digestLength!Hash)
 				{
 					//begin and end of random number array
 					ubyte[] begin = rand[0..digestLength!Hash];


### PR DESCRIPTION
This pull request depends on https://github.com/dlang/dmd/pull/13169, trying to catch an out of bounds slice at compile time. Currently this would result in a compilation error at line 562, but given the fact that both digestLength!Hash and bufferSize are known at compile time, by replacing if with static if the program will work as expected.