### PR TITLE
Add nothrow to vibe.http.client.defaultSettings

### DIFF
--- a/http/vibe/http/client.d
+++ b/http/vibe/http/client.d
@@ -1284,7 +1284,7 @@ package auto getFilteredHost(URL url)
 
 // This object is a placeholder and should to never be modified.
 package @property const(HTTPClientSettings) defaultSettings()
-@trusted {
+@trusted nothrow {
 	__gshared HTTPClientSettings ret = new HTTPClientSettings;
 	return ret;
 }


### PR DESCRIPTION
`defaultSettings` does not throw.
