### PR TITLE
Remove usage of shared static this in examples

### DIFF
--- a/examples/app_skeleton/dub.json
+++ b/examples/app_skeleton/dub.json
@@ -1,13 +1,7 @@
 ﻿{
 	"name": "app-skeleton",
 	"description": "An example project skeleton",
-	"homepage": "http://my-project.org",
-	"copyright": "Copyright © 2000, Toni Tester",
-	"authors": [
-		"Toni Tester"
-	],
 	"dependencies": {
 		"vibe-d": {"path": "../../"}
-	},
-	"versions": ["VibeDefaultMain"]
+	}
 }

--- a/examples/app_skeleton/source/app.d
+++ b/examples/app_skeleton/source/app.d
@@ -1,5 +1,6 @@
 module app;
 
+import vibe.core.core;
 import vibe.http.fileserver;
 import vibe.http.router;
 import vibe.http.server;
@@ -12,7 +13,7 @@ void showError(HTTPServerRequest req, HTTPServerResponse res, HTTPServerErrorInf
 	res.render!("error.dt", req, error);
 }
 
-shared static this()
+int main(string[] args)
 {
 	auto router = new URLRouter;
 	router.get("/", &showHome);
@@ -24,5 +25,6 @@ shared static this()
 	settings.port = 8080;
 	settings.errorPageHandler = toDelegate(&showError);
 
-	listenHTTP(settings, router);
+	auto listener = listenHTTP(settings, router);
+	return runApplication(&args);
 }

--- a/examples/auth_basic/dub.json
+++ b/examples/auth_basic/dub.json
@@ -3,6 +3,5 @@
 	"description": "Demonstrates basic authentication.",
 	"dependencies": {
 		"vibe-d:http": {"path": "../../"}
-	},
-	"versions": ["VibeDefaultMain"]
+	}
 }

--- a/examples/auth_basic/source/app.d
+++ b/examples/auth_basic/source/app.d
@@ -1,4 +1,6 @@
-import vibe.appmain;
+module app;
+
+import vibe.core.core;
 import vibe.http.auth.basic_auth;
 import vibe.http.router;
 import vibe.http.server;
@@ -9,7 +11,7 @@ bool checkPassword(string user, string password)
 	return user == "admin" && password == "secret";
 }
 
-shared static this()
+int main(string[] args)
 {
 	auto router = new URLRouter;
 
@@ -26,5 +28,6 @@ shared static this()
 	settings.port = 8080;
 	settings.bindAddresses = ["::1", "127.0.0.1"];
 
-	listenHTTP(settings, router);
+	auto listener = listenHTTP(settings, router);
+	return runApplication(&args);
 }

--- a/examples/auth_digest/dub.json
+++ b/examples/auth_digest/dub.json
@@ -3,6 +3,5 @@
 	"description": "Demonstrates digest authentication.",
 	"dependencies": {
 		"vibe-d:http": {"path": "../../"}
-	},
-	"versions": ["VibeDefaultMain"]
+	}
 }

--- a/examples/auth_digest/source/app.d
+++ b/examples/auth_digest/source/app.d
@@ -1,4 +1,6 @@
-import vibe.appmain;
+module app;
+
+import vibe.core.core;
 import vibe.http.auth.digest_auth;
 import vibe.http.router;
 import vibe.http.server;
@@ -11,7 +13,7 @@ string digestPassword(string realm, string user) @safe
 	return "";
 }
 
-shared static this()
+int main(string[] args)
 {
 	auto authinfo = new DigestAuthInfo;
 	authinfo.realm = "Site Realm";
@@ -31,5 +33,6 @@ shared static this()
 	settings.port = 8080;
 	settings.bindAddresses = ["::1", "127.0.0.1"];
 
-	listenHTTP(settings, router);
+	auto listener = listenHTTP(settings, router);
+	return runApplication(&args);
 }

--- a/examples/bench-http-server/dub.json
+++ b/examples/bench-http-server/dub.json
@@ -3,5 +3,5 @@
 	"dependencies": {
 		"vibe-d:http": {"path": "../../"}
 	},
-	"versions": ["VibeDefaultMain", "VibeManualMemoryManagement"]
+	"versions": ["VibeManualMemoryManagement"]
 }

--- a/examples/bench-http-server/source/app.d
+++ b/examples/bench-http-server/source/app.d
@@ -1,4 +1,5 @@
-import vibe.appmain;
+module app;
+
 import vibe.core.core;
 import vibe.http.fileserver;
 import vibe.http.router;
@@ -63,7 +64,7 @@ pure char[] generateData()
 }
 
 
-shared static this()
+int main(string[] args)
 {
 	//setLogLevel(LogLevel.Trace);
 	data = generateData();
@@ -89,7 +90,10 @@ shared static this()
 		routes.get("/file/*", serveStaticFiles("./public", fsettings));
 		routes.rebuild();
 
-		listenHTTP(settings, routes);
-		listenTCP(8081, toDelegate(&staticAnswer), "127.0.0.1", TCPListenOptions.reusePort);
+		auto httpListener = listenHTTP(settings, routes);
+		auto tcpListener  = listenTCP(8081, toDelegate(&staticAnswer),
+			"127.0.0.1", TCPListenOptions.reusePort);
 	});
+
+	return runApplication(&args);
 }

--- a/examples/diet/dub.json
+++ b/examples/diet/dub.json
@@ -3,6 +3,5 @@
 	"description": "Displays a page using a Diet template.",
 	"dependencies": {
 		"vibe-d:http": {"path": "../../"}
-	},
-	"versions": ["VibeDefaultMain"]
+	}
 }

--- a/examples/diet/source/app.d
+++ b/examples/diet/source/app.d
@@ -1,4 +1,6 @@
-import vibe.appmain;
+module app;
+
+import vibe.core.core;
 import vibe.http.server;
 
 void handleRequest(scope HTTPServerRequest req, scope HTTPServerResponse res)
@@ -10,11 +12,12 @@ void handleRequest(scope HTTPServerRequest req, scope HTTPServerResponse res)
 	res.render!("diet.dt", req, local_var, is_admin);
 }
 
-shared static this()
+int main(string[] args)
 {
 	auto settings = new HTTPServerSettings;
 	settings.port = 8080;
 	settings.bindAddresses = ["::1", "127.0.0.1"];
 
-	listenHTTP(settings, &handleRequest);
+	auto listener = listenHTTP(settings, &handleRequest);
+	return runApplication(&args);
 }

--- a/examples/echoserver/dub.json
+++ b/examples/echoserver/dub.json
@@ -3,6 +3,5 @@
 	"description": "Implementation of a minimal echo server.",
 	"dependencies": {
 		"vibe-d:core": {"path": "../../"}
-	},
-	"versions": ["VibeDefaultMain"]
+	}
 }

--- a/examples/echoserver/source/app.d
+++ b/examples/echoserver/source/app.d
@@ -1,11 +1,14 @@
-import vibe.appmain;
+module app;
+
+import vibe.core.core;
 import vibe.core.net;
 import vibe.core.stream;
 
-shared static this()
+int main(string[] args)
 {
-	listenTCP(2000, (conn) {
+	auto listener = listenTCP(2000, (conn) {
 		try conn.pipe(conn);
 		catch (Exception e) conn.close();
 	});
+	return runApplication(&args);
 }

--- a/examples/future/dub.json
+++ b/examples/future/dub.json
@@ -4,6 +4,5 @@
 	"authors": ["Sönke Ludwig"],
 	"dependencies": {
 		"vibe-d:core": {"path": "../../"}
-	},
-	"versions": ["VibeDefaultMain"]
+	}
 }

--- a/examples/future/source/app.d
+++ b/examples/future/source/app.d
@@ -1,13 +1,14 @@
-import vibe.appmain;
+module app;
+
+import vibe.core.core;
 import vibe.core.core;
 import vibe.core.log;
 import vibe.core.concurrency;
 import core.time;
 
-
-shared static this()
+int main(string[] args)
 {
-	runTask({
+	auto taskHandler = runTask({
 		auto val = async({
 			logInfo("Starting to compute value.");
 			sleep(500.msecs); // simulate some lengthy computation
@@ -21,4 +22,6 @@ shared static this()
 		logInfo("Result: %s", val.getResult());
 		exitEventLoop();
 	});
+
+	return runApplication(&args);
 }

--- a/examples/http_forward_proxy/dub.json
+++ b/examples/http_forward_proxy/dub.json
@@ -3,6 +3,5 @@
 	"description": "Sets up a simple forward proxy.",
 	"dependencies": {
 		"vibe-d:http": {"path": "../../"}
-	},
-	"versions": ["VibeDefaultMain"]
+	}
 }

--- a/examples/http_forward_proxy/source/app.d
+++ b/examples/http_forward_proxy/source/app.d
@@ -1,13 +1,15 @@
-import vibe.appmain;
+module app;
+
+import vibe.core.core;
 import vibe.http.proxy;
 import vibe.http.server;
 
-
-shared static this()
+int main(string[] args)
 {
 	auto settings = new HTTPServerSettings;
 	settings.port = 8080;
 	settings.bindAddresses = ["::1", "127.0.0.1"];
 
 	listenHTTPForwardProxy(settings);
+	return runApplication(&args);
 }

--- a/examples/http_info/dub.json
+++ b/examples/http_info/dub.json
@@ -3,6 +3,5 @@
 	"description": "Displays request information using a Diet template.",
 	"dependencies": {
 		"vibe-d:http": {"path": "../../"}
-	},
-	"versions": ["VibeDefaultMain"]
+	}
 }

--- a/examples/http_info/source/app.d
+++ b/examples/http_info/source/app.d
@@ -1,12 +1,15 @@
-import vibe.appmain;
+module app;
+
+import vibe.core.core;
 import vibe.http.server;
 
-shared static this()
+int main (string[] args)
 {
 	auto settings = new HTTPServerSettings;
 	settings.sessionStore = new MemorySessionStore();
 	settings.port = 8080;
 	settings.bindAddresses = ["::1", "127.0.0.1"];
 
-	listenHTTP(settings, staticTemplate!("info.dt"));
+	auto listener = listenHTTP(settings, staticTemplate!("info.dt"));
+	return runApplication(&args);
 }

--- a/examples/http_reverse_proxy/dub.json
+++ b/examples/http_reverse_proxy/dub.json
@@ -3,6 +3,5 @@
 	"description": "Sets up a simple reverse proxy to a foreign server.",
 	"dependencies": {
 		"vibe-d:http": {"path": "../../"}
-	},
-	"versions": ["VibeDefaultMain"]
+	}
 }

--- a/examples/http_reverse_proxy/source/app.d
+++ b/examples/http_reverse_proxy/source/app.d
@@ -1,13 +1,15 @@
-import vibe.appmain;
+module app;
+
+import vibe.core.core;
 import vibe.http.proxy;
 import vibe.http.server;
 
-
-shared static this()
+int main(string[] args)
 {
 	auto settings = new HTTPServerSettings;
 	settings.port = 8080;
 	settings.bindAddresses = ["::1", "127.0.0.1"];
 
 	listenHTTPReverseProxy(settings, "vibed.org", 80);
+	return runApplication(&args);
 }

--- a/examples/https_server_sni/dub.json
+++ b/examples/https_server_sni/dub.json
@@ -3,6 +3,5 @@
 	"description": "Uses SNI to serve multiple virtual hosts in a single HTTPS port.",
 	"dependencies": {
 		"vibe-d:http": {"path": "../../"}
-	},
-	"versions": ["VibeDefaultMain"]
+	}
 }

--- a/examples/https_server_sni/source/app.d
+++ b/examples/https_server_sni/source/app.d
@@ -1,10 +1,11 @@
-import vibe.appmain;
+module app;
+
+import vibe.core.core;
 import vibe.core.log;
 import vibe.http.server;
 import vibe.stream.tls;
 
-
-shared static this()
+int main(string[] args)
 {
 	{
 		auto settings = new HTTPServerSettings;
@@ -40,6 +41,8 @@ You can then navigate to either https://hosta:8080/ or https://hostb:8080/
 and should be presented with a different certificate each time, matching the
 host name entered.
 `);
+
+	return runApplication(&args);
 }
 
 void handleRequestA(scope HTTPServerRequest req, scope HTTPServerResponse res)

--- a/examples/message/dub.json
+++ b/examples/message/dub.json
@@ -3,6 +3,5 @@
 	"description": "Demonstrates cross-task message communication.",
 	"dependencies": {
 		"vibe-d:core": {"path": "../../"}
-	},
-	"versions": ["VibeDefaultMain"]
+	}
 }

--- a/examples/message/source/app.d
+++ b/examples/message/source/app.d
@@ -1,11 +1,11 @@
-import vibe.appmain;
+module app;
+
 import vibe.core.core;
 import vibe.core.log;
 import vibe.core.concurrency;
 import core.time;
 
-
-shared static this()
+int main(string[] args)
 {
 	auto t1 = runTask({
 		while (true) {
@@ -53,4 +53,6 @@ shared static this()
 		logInfo("send string Bye bye");
 		t1.send("Bye bye");
 	});
+
+	return runApplication(&args);
 }

--- a/examples/read_write_mutex/dub.json
+++ b/examples/read_write_mutex/dub.json
@@ -6,7 +6,6 @@
 		"vibe-d": {"version": "~master", "path": "../../"}
 	},
 	"versions": [
-		"VibeDefaultMain",
 		"RWMutexPrint",
 	],
 }

--- a/examples/read_write_mutex/source/app.d
+++ b/examples/read_write_mutex/source/app.d
@@ -1,3 +1,4 @@
+module app;
 
 import vibe.d;
 
@@ -58,7 +59,7 @@ __gshared {
 	ulong s_runningTasks;
 }
 
-shared static this()
+int main(string[] args)
 {
 	s_taskMutex = new TaskMutex();
 	s_taskCondition = new TaskCondition(s_taskMutex);
@@ -78,7 +79,7 @@ shared static this()
 
 	//Wait for a couple of seconds for the server to be initialized properly and then start
 	//multiple concurrent threads that simultaneously start queries on the rest interface defined above.
-	setTimer(500.msecs, () @trusted  {
+	setTimer(500.msecs, () @trusted {
 		scope (failure) assert(false);
 
 		scope(exit)
@@ -109,4 +110,6 @@ shared static this()
 			while(s_runningTasks > 0);
 		}
 	});
+
+	return runApplication(&args);
 }

--- a/examples/redis-pubsub/dub.json
+++ b/examples/redis-pubsub/dub.json
@@ -3,6 +3,5 @@
 	"description": "Basic Redis Pub/Sub usage example.",
 	"dependencies": {
 		"vibe-d:redis": {"path": "../../"}
-	},
-	"versions": ["VibeDefaultMain"]
+	}
 }

--- a/examples/redis-pubsub/source/app.d
+++ b/examples/redis-pubsub/source/app.d
@@ -1,8 +1,12 @@
-import core.time;
-import std.functional;
+module app;
+
 import vibe.core.core;
 import vibe.core.log;
 import vibe.db.redis.redis;
+
+import std.functional;
+
+import core.time;
 
 void printReply(string channel, string message) @safe
 {
@@ -11,7 +15,7 @@ void printReply(string channel, string message) @safe
 
 RedisSubscriber subscriber;
 
-shared static this()
+int main(string[] args)
 {
 	auto publisher = new RedisClient();
 	subscriber = publisher.createSubscriber();
@@ -21,10 +25,11 @@ shared static this()
 	publisher.getDatabase(0).publish("test1", "Hello World!");
 	publisher.getDatabase(0).publish("test2", "Hello from Channel 2");
 
-
-	runTask({
+	auto taskHandler = runTask({
 		subscriber.subscribe("test-fiber");
 		publisher.getDatabase(0).publish("test-fiber", "Hello from the Fiber!");
 		subscriber.unsubscribe();
 	});
+
+	return runApplication(&args);
 }

--- a/examples/rest-collections/dub.json
+++ b/examples/rest-collections/dub.json
@@ -3,6 +3,5 @@
     "description": "Example project demonstrating the use of collections in REST interfaces.",
     "dependencies": {
         "vibe-d": {"path": "../../"}
-    },
-    "versions": ["VibeDefaultMain"]
+    }
 }

--- a/examples/rest-collections/source/app.d
+++ b/examples/rest-collections/source/app.d
@@ -83,7 +83,7 @@ class LocalPostAPI : PostAPI {
 	}
 }
 
-shared static this()
+int main(string[] args)
 {
 	auto router = new URLRouter;
 	router.registerRestInterface(new LocalForumAPI);
@@ -91,9 +91,9 @@ shared static this()
 	auto settings = new HTTPServerSettings;
 	settings.bindAddresses = ["127.0.0.1"];
 	settings.port = 8080;
-	listenHTTP(settings, router);
+	auto listener = listenHTTP(settings, router);
 
-	runTask({
+	auto taskHandler = runTask({
 		auto api = new RestInterfaceClient!ForumAPI("http://127.0.0.1:8080/");
 		logInfo("Current number of threads: %s", api.threads.get().length);
 		logInfo("Posting a topic...");
@@ -109,4 +109,6 @@ shared static this()
 		}
 		logInfo("Leaving REST server running. Hit Ctrl+C to exit.");
 	});
+
+	return runApplication(&args);
 }

--- a/examples/rest-js/dub.json
+++ b/examples/rest-js/dub.json
@@ -3,6 +3,5 @@
 	"description": "Simple dynamic web UI that accesses a REST interface",
 	"dependencies": {
 		"vibe-d": { "path": "../../" }
-	},
-	"versions": ["VibeDefaultMain"]
+	}
 }

--- a/examples/rest-js/source/app.d
+++ b/examples/rest-js/source/app.d
@@ -1,3 +1,6 @@
+module app;
+
+import vibe.core.core;
 import vibe.web.rest;
 import vibe.http.common : HTTPMethod;
 
@@ -18,7 +21,7 @@ class Test : ITest {
 	void postToConsole(string text) { writeln(text); }
 }
 
-shared static this()
+int main(string[] args)
 {
 	import vibe.core.log : logInfo;
 	import vibe.inet.url : URL;
@@ -43,7 +46,9 @@ shared static this()
 	auto settings = new HTTPServerSettings;
 	settings.port = 8080;
 	settings.bindAddresses = ["::1", "127.0.0.1"];
-	listenHTTP(settings, router);
+
+	auto listener = listenHTTP(settings, router);
 
 	logInfo("Please open http://127.0.0.1:8080/ in your browser.");
+	return runApplication(&args);
 }

--- a/examples/rest/dub.json
+++ b/examples/rest/dub.json
@@ -3,6 +3,5 @@
 	"description": "Shows how the REST interface generator can be used for RPC communication.",
 	"dependencies": {
 		"vibe-d:web": {"path": "../../"}
-	},
-	"versions": ["VibeDefaultMain"]
+	}
 }

--- a/examples/rest/source/app.d
+++ b/examples/rest/source/app.d
@@ -3,8 +3,8 @@
  * introduces few new more advanced features. Sometimes registration code in module constructor
  * is also important, it is then mentioned in example comment explicitly.
  */
+module app;
 
-import vibe.appmain;
 import vibe.core.core;
 import vibe.core.log;
 import vibe.data.json;
@@ -476,7 +476,7 @@ class Example7 : Example7API {
 }
 
 
-shared static this()
+int main(string[] args)
 {
 	// Registering our REST services in router
 	auto routes = new URLRouter;
@@ -494,7 +494,7 @@ shared static this()
 	settings.port = 8080;
 	settings.bindAddresses = ["::1", "127.0.0.1"];
 
-	listenHTTP(settings, routes);
+	auto listener = listenHTTP(settings, routes);
 
 	/* At this moment, server is prepared to process requests.
 	 * After a small delay to let socket become ready, the very same D interfaces
@@ -633,4 +633,6 @@ shared static this()
 
 		logInfo("Success.");
 	});
+
+	return runApplication(&args);
 }

--- a/examples/task_control/dub.json
+++ b/examples/task_control/dub.json
@@ -3,6 +3,5 @@
 	"description": "Task manipulation example.",
 	"dependencies": {
 		"vibe-d:http": {"path": "../../"}
-	},
-	"versions": ["VibeDefaultMain"]
+	}
 }

--- a/examples/task_control/source/app.d
+++ b/examples/task_control/source/app.d
@@ -1,4 +1,5 @@
-import vibe.appmain;
+module app;
+
 import vibe.core.core;
 import vibe.core.log;
 import vibe.http.router;
@@ -21,7 +22,7 @@ void interrupt(HTTPServerRequest req, HTTPServerResponse res)
 	res.redirect("/");
 }
 
-shared static this()
+int main(string[] args)
 {
 	g_task = runTask({
 		logInfo("Starting task, waiting for max. 10 seconds.");
@@ -41,7 +42,9 @@ shared static this()
 
 	auto settings = new HTTPServerSettings;
 	settings.port = 8080;
-	listenHTTP(settings, routes);
+
+	auto listener = listenHTTP(settings, routes);
 
 	logInfo("Please open http://localhost:8080/ in a browser to monitor or interrupt the task.");
+	return runApplication(&args);
 }

--- a/examples/tcp_separate/dub.json
+++ b/examples/tcp_separate/dub.json
@@ -4,6 +4,5 @@
 	"dependencies": {
 		"vibe-d:core": {"path": "../../"},
 		"vibe-d:stream": {"path": "../../"}
-	},
-	"versions": ["VibeDefaultMain"]
+	}
 }

--- a/examples/tcp_separate/source/app.d
+++ b/examples/tcp_separate/source/app.d
@@ -1,16 +1,17 @@
-import vibe.appmain;
-import vibe.core.core : runTask, sleep;
+module app;
+
+import vibe.core.core;
 import vibe.core.log : logError, logInfo;
 import vibe.core.net : TCPConnection, listenTCP;
 import vibe.stream.operations : readLine;
 
 import core.time;
 
-shared static this()
+int main(string[] args)
 {
 	// shows how to handle reading and writing of the TCP connection
 	// in separate tasks
-	listenTCP(7000, (conn) {
+	auto listener = listenTCP(7000, (conn) {
 		auto wtask = runTask!TCPConnection((conn) {
 			try {
 				while (conn.connected) {
@@ -37,4 +38,6 @@ shared static this()
 
 		conn.close();
 	});
+
+	return runApplication(&args);
 }

--- a/examples/udp/dub.json
+++ b/examples/udp/dub.json
@@ -3,6 +3,5 @@
 	"description": "Sends UDP packets from one socket to another.",
 	"dependencies": {
 		"vibe-d:core": {"path": "../../"}
-	},
-	"versions": ["VibeDefaultMain"]
+	}
 }

--- a/examples/udp/source/app.d
+++ b/examples/udp/source/app.d
@@ -5,10 +5,9 @@ import vibe.core.net;
 
 import core.time;
 
-
-shared static this()
+int main(string[] args)
 {
-	runTask({
+	auto t1Hansler = runTask({
 		auto udp_listener = listenUDP(1234);
 		while (true) {
 			auto pack = udp_listener.recv();
@@ -16,7 +15,7 @@ shared static this()
 		}
 	});
 
-	runTask({
+	auto t2Handler = runTask({
 		auto udp_sender = listenUDP(0);
 		udp_sender.connect("127.0.0.1", 1234);
 		while (true) {
@@ -25,4 +24,6 @@ shared static this()
 			udp_sender.send(cast(ubyte[])"Hello, World!");
 		}
 	});
+
+	return runApplication(&args);
 }

--- a/examples/uploader/dub.json
+++ b/examples/uploader/dub.json
@@ -3,6 +3,5 @@
 	"description": "Simple form based file upload example.",
 	"dependencies": {
 		"vibe-d:http": {"path": "../../"}
-	},
-	"versions": ["VibeDefaultMain"]
+	}
 }

--- a/examples/uploader/source/app.d
+++ b/examples/uploader/source/app.d
@@ -1,4 +1,6 @@
-import vibe.appmain;
+module app;
+
+import vibe.core.core;
 import vibe.core.file;
 import vibe.core.log;
 import vibe.core.path;
@@ -6,7 +8,6 @@ import vibe.http.router;
 import vibe.http.server;
 
 import std.exception;
-
 
 void uploadFile(scope HTTPServerRequest req, scope HTTPServerResponse res)
 {
@@ -22,7 +23,7 @@ void uploadFile(scope HTTPServerRequest req, scope HTTPServerResponse res)
 	res.writeBody("File uploaded!", "text/plain");
 }
 
-shared static this()
+int main(string[] args)
 {
 	auto router = new URLRouter;
 	router.get("/", staticTemplate!"upload_form.dt");
@@ -31,5 +32,7 @@ shared static this()
 	auto settings = new HTTPServerSettings;
 	settings.port = 8080;
 	settings.bindAddresses = ["::1", "127.0.0.1"];
-	listenHTTP(settings, router);
+
+	auto listener = listenHTTP(settings, router);
+	return runApplication(&args);
 }

--- a/examples/web-auth/dub.json
+++ b/examples/web-auth/dub.json
@@ -3,6 +3,5 @@
 	"description": "Simple service using the web framework.",
 	"dependencies": {
 		"vibe-d:web": {"path": "../../"}
-	},
-	"versions": ["VibeDefaultMain"]
+	}
 }

--- a/examples/web-auth/source/app.d
+++ b/examples/web-auth/source/app.d
@@ -4,6 +4,7 @@
 module app;
 
 import std.exception : enforce;
+import vibe.core.core;
 import vibe.core.log;
 import vibe.http.fileserver;
 import vibe.http.router;
@@ -15,8 +16,8 @@ import vibe.web.web;
 // Aggregates information and roles about the currently logged in user
 struct AuthInfo {
 	string userName;
-    bool premium;
-    bool admin;
+	bool premium;
+	bool admin;
 
 	@safe:
 	bool isAdmin() { return this.admin; }
@@ -148,7 +149,7 @@ class SampleService {
 }
 
 
-shared static this()
+int main(string[] args)
 {
 	// Create the router that will dispatch each request to the proper handler method
 	auto router = new URLRouter;
@@ -164,7 +165,9 @@ shared static this()
 	settings.port = 8080;
 	settings.bindAddresses = ["::1", "127.0.0.1"];
 	settings.sessionStore = new MemorySessionStore;
-	listenHTTP(settings, router);
+
+	auto listener =listenHTTP(settings, router);
 
 	logInfo("Please open http://127.0.0.1:8080/ in your browser.");
+	return runApplication(&args);
 }

--- a/examples/web-i18n/dub.json
+++ b/examples/web-i18n/dub.json
@@ -4,6 +4,5 @@
 	"dependencies": {
 		"vibe-d:web": {"path": "../../"}
 	},
-	"stringImportPaths": ["views", "translations"],
-	"versions": ["VibeDefaultMain"]
+	"stringImportPaths": ["views", "translations"]
 }

--- a/examples/web-i18n/source/app.d
+++ b/examples/web-i18n/source/app.d
@@ -1,6 +1,7 @@
 // This module shows the translation support of the vibe.web.web framework.
 module app;
 
+import vibe.core.core;
 import vibe.core.log;
 import vibe.http.fileserver;
 import vibe.http.router;
@@ -38,7 +39,7 @@ class SampleService {
 	}
 }
 
-shared static this()
+int main(string[] args)
 {
 	// Create the router that will map the incoming requests to request handlers
 	auto router = new URLRouter;
@@ -52,7 +53,9 @@ shared static this()
 	settings.port = 8080;
 	settings.bindAddresses = ["::1", "127.0.0.1"];
 	settings.sessionStore = new MemorySessionStore;
-	listenHTTP(settings, router);
+
+	auto listener = listenHTTP(settings, router);
 
 	logInfo("Please open http://127.0.0.1:8080/ in your browser.");
+	return runApplication(&args);
 }

--- a/examples/web/dub.json
+++ b/examples/web/dub.json
@@ -3,6 +3,5 @@
 	"description": "Simple service using the web framework.",
 	"dependencies": {
 		"vibe-d:web": {"path": "../../"}
-	},
-	"versions": ["VibeDefaultMain"]
+	}
 }

--- a/examples/web/source/app.d
+++ b/examples/web/source/app.d
@@ -3,6 +3,7 @@
 module app;
 
 import std.exception : enforce;
+import vibe.core.core;
 import vibe.core.log;
 import vibe.http.fileserver;
 import vibe.http.router;
@@ -124,7 +125,7 @@ class SampleService {
 }
 
 
-shared static this()
+int main(string[] args)
 {
 	// Create the router that will dispatch each request to the proper handler method
 	auto router = new URLRouter;
@@ -140,7 +141,9 @@ shared static this()
 	settings.port = 8080;
 	settings.bindAddresses = ["::1", "127.0.0.1"];
 	settings.sessionStore = new MemorySessionStore;
-	listenHTTP(settings, router);
+
+	auto listener = listenHTTP(settings, router);
 
 	logInfo("Please open http://127.0.0.1:8080/ in your browser.");
+	return runApplication(&args);
 }

--- a/examples/web_ajax/dub.json
+++ b/examples/web_ajax/dub.json
@@ -3,6 +3,5 @@
 	"description": "Uses the registerWebInterface function for making functions available to JavaScript and to Diet templates.",
 	"dependencies": {
 		"vibe-d:web": {"path": "../../"}
-	},
-	"versions": ["VibeDefaultMain"]
+	}
 }

--- a/examples/web_ajax/source/app.d
+++ b/examples/web_ajax/source/app.d
@@ -6,7 +6,7 @@
 */
 module app;
 
-import vibe.appmain;
+import vibe.core.core;
 import vibe.http.router;
 import vibe.http.server;
 import vibe.web.web;
@@ -133,7 +133,7 @@ class App {
 	}
 }
 
-shared static this()
+int main(string[] args)
 {
 	auto router = new URLRouter;
 	router.registerWebInterface(new App);
@@ -142,5 +142,6 @@ shared static this()
 	settings.port = 8080;
 	settings.bindAddresses = ["::1", "127.0.0.1"];
 
-	listenHTTP(settings, router);
+	auto listener = listenHTTP(settings, router);
+	return runApplication(&args);
 }

--- a/examples/web_websocket/dub.json
+++ b/examples/web_websocket/dub.json
@@ -4,6 +4,5 @@
 	"authors": [ "Darius C." ],
 	"dependencies": {
 		"vibe-d": {"version": "~master", "path": "../../"}
-	},
-	"versions": ["VibeDefaultMain"]
+	}
 }

--- a/examples/web_websocket/source/app.d
+++ b/examples/web_websocket/source/app.d
@@ -1,7 +1,6 @@
 module app;
 
-import vibe.core.core : sleep;
-
+import vibe.core.core;
 import vibe.core.log;
 import vibe.http.fileserver : serveStaticFiles;
 import vibe.http.router : URLRouter;
@@ -33,7 +32,7 @@ class WebsocketService {
 }
 
 
-shared static this()
+int main(string[] args)
 {
 	auto router = new URLRouter;
 
@@ -44,7 +43,8 @@ shared static this()
 	auto settings = new HTTPServerSettings;
 	settings.port = 8080;
 	settings.bindAddresses = ["::1", "127.0.0.1"];
-	listenHTTP(settings, router);
+	auto listener = listenHTTP(settings, router);
 
 	logInfo("Please open http://127.0.0.1:8080/ in your browser.");
+	return runApplication(&args);
 }

--- a/examples/websocket/dub.json
+++ b/examples/websocket/dub.json
@@ -3,6 +3,5 @@
 	"description": "Example for using the WebSocket feature",
 	"dependencies": {
 		"vibe-d:http": {"path": "../../"}
-	},
-	"versions": ["VibeDefaultMain"]
+	}
 }

--- a/examples/websocket/source/app.d
+++ b/examples/websocket/source/app.d
@@ -1,4 +1,6 @@
-import vibe.core.core : sleep;
+module app;
+
+import vibe.core.core;
 import vibe.core.log;
 import vibe.http.fileserver : serveStaticFiles;
 import vibe.http.router : URLRouter;
@@ -9,7 +11,7 @@ import core.time;
 import std.conv : to;
 
 
-shared static this()
+int main(string[] args)
 {
 	auto router = new URLRouter;
 	router.get("/", staticRedirect("/index.html"));
@@ -19,7 +21,9 @@ shared static this()
 	auto settings = new HTTPServerSettings;
 	settings.port = 8080;
 	settings.bindAddresses = ["::1", "127.0.0.1"];
-	listenHTTP(settings, router);
+
+	auto listener = listenHTTP(settings, router);
+	return runApplication(&args);
 }
 
 void handleWebSocketConnection(scope WebSocket socket)

--- a/http/vibe/http/websockets.d
+++ b/http/vibe/http/websockets.d
@@ -486,9 +486,10 @@ unittest
  * Represents a single _WebSocket connection.
  *
  * ---
- * shared static this ()
+ * int main (string[] args)
  * {
- *   runTask(() => connectToWS());
+ *   auto taskHandle = runTask(() => connectToWS());
+ *   return runApplication(&args);
  * }
  *
  * void connectToWS ()
@@ -1132,7 +1133,7 @@ private struct Frame {
 		}
 
 		if (sys_rng) {
-            sys_rng.read(dst[0 .. 4]);
+			sys_rng.read(dst[0 .. 4]);
 			for (size_t i = 0; i < payload.length; i++)
 				payload[i] ^= dst[i % 4];
 		}

--- a/tests/not-runnable/vibe.http.websocket-autobahn-client/dub.json
+++ b/tests/not-runnable/vibe.http.websocket-autobahn-client/dub.json
@@ -2,8 +2,5 @@
 	"name": "websockets-autobahn-client",
 	"dependencies": {
 		"vibe-d": { "path": "../../" }
-	},
-	"versions": [
-		"VibeDefaultMain"
-	]
+	}
 }

--- a/tests/not-runnable/vibe.http.websocket-autobahn-client/source/app.d
+++ b/tests/not-runnable/vibe.http.websocket-autobahn-client/source/app.d
@@ -1,41 +1,44 @@
+module app;
+
 import vibe.d;
 
-shared static this ()
+int main (string[] args)
 {
-    runTask(() => runTestSuite());
+	auto raskHandler = runTask(() => runTestSuite());
+	return runApplication(&args);
 }
 
 void runTestSuite ()
 {
-    auto count = getCaseCount();
-    logInfo("We're going to run %d test cases...", count);
+	auto count = getCaseCount();
+	logInfo("We're going to run %d test cases...", count);
 
-    foreach (currCase; 1 .. count)
-    {
-        auto url = URL("ws://127.0.0.1:9001/runCase?agent=vibe.d&case="
-                       ~ to!string(currCase));
-        logInfo("Running test case %d/%d", currCase, count);
-        connectWebSocket(
-            url, (scope ws) {
-                while (ws.waitForData) {
-                    ws.receive((scope message) {
-                        ws.send(message.readAll);
-                    });
-                }
-            });
-    }
+	foreach (currCase; 1 .. count)
+	{
+		auto url = URL("ws://127.0.0.1:9001/runCase?agent=vibe.d&case="
+					   ~ to!string(currCase));
+		logInfo("Running test case %d/%d", currCase, count);
+		connectWebSocket(
+			url, (scope ws) {
+				while (ws.waitForData) {
+					ws.receive((scope message) {
+						ws.send(message.readAll);
+					});
+				}
+			});
+	}
 }
 
 
 size_t getCaseCount (string base_addr = "ws://127.0.0.1:9001")
 {
-    size_t ret;
-    auto url = URL(base_addr ~ "/getCaseCount");
-    connectWebSocket(
-        url, (scope ws) {
-            while (ws.waitForData) {
-                ret = ws.receiveText.to!size_t;
-            }
-        });
-    return ret;
+	size_t ret;
+	auto url = URL(base_addr ~ "/getCaseCount");
+	connectWebSocket(
+		url, (scope ws) {
+			while (ws.waitForData) {
+				ret = ws.receiveText.to!size_t;
+			}
+		});
+	return ret;
 }


### PR DESCRIPTION
```
It has been discussed and decided in vibe.d/vibe.d#2370 that 'shared static this'
was an early feature that nowadays should go.
The first step to that is to remove it from examples so new users
will not be tempted to use it.

In addition, the examples were tidied up a bit, by always adding a module declaration,
and storing the return values of listen* / runTask whenever applicable.
Some places used spaces instead of tabs, which was also fixed.
```