### PR TITLE
URL: Account for port in opEquals

### DIFF
--- a/inet/vibe/inet/url.d
+++ b/inet/vibe/inet/url.d
@@ -557,6 +557,7 @@ struct URL {
 		if (m_schema != rhs.m_schema) return false;
 		if (m_host != rhs.m_host) return false;
 		if (m_path != rhs.m_path) return false;
+		if (m_port != rhs.m_port) return false;
 		return true;
 	}
 	/// ditto


### PR DESCRIPTION
Port check was missing. We can take default port into account for this, but since we have an URL normalizer, we can leave it to the user.

So, with this check; without normalization
`http://example.com/` and `http://example.com:80` will not be equal