### PR TITLE
OpenSSL TLS version handling improvements

### DIFF
--- a/stream/vibe/stream/taskpipe.d
+++ b/stream/vibe/stream/taskpipe.d
@@ -145,6 +145,7 @@ private final class TaskPipeImpl {
 				} else while (m_buffer.full) {
 					if (mode == IOMode.immediate || mode == IOMode.once && ret > 0)
 						return ret;
+					if (m_closed) throw new Exception("Pipe closed while writing data");
 					() @trusted { m_condition.wait(); } ();
 				}
 

--- a/tests/tls/dub.json
+++ b/tests/tls/dub.json
@@ -2,6 +2,6 @@
     "name": "tests",
     "description": "TLS tunnel and certificate test",
     "dependencies": {
-        "vibe-d": {"path": "../../"}
+        "vibe-d:tls": {"path": "../../"}
     }
 }

--- a/tls/vibe/stream/openssl.d
+++ b/tls/vibe/stream/openssl.d
@@ -626,9 +626,7 @@ final class OpenSSLContext : TLSContext {
 				final switch (ver) {
 					case TLSVersion.any: method = SSLv23_client_method(); veroptions |= SSL_OP_NO_SSLv3; break;
 					case TLSVersion.ssl3: throw new Exception("SSLv3 is not supported anymore");
-					case TLSVersion.tls1: method = TLSv1_client_method(); veroptions |= SSL_OP_NO_SSLv3; break;
-					//case TLSVersion.tls1_1: method = TLSv1_1_client_method(); break;
-					//case TLSVersion.tls1_2: method = TLSv1_2_client_method(); break;
+					case TLSVersion.tls1: method = SSLv23_client_method(); veroptions |= SSL_OP_NO_SSLv3|SSL_OP_NO_TLSv1_1|SSL_OP_NO_TLSv1_2; maxver = TLS1_VERSION; break;
 					case TLSVersion.tls1_1: method = SSLv23_client_method(); veroptions |= SSL_OP_NO_SSLv3|SSL_OP_NO_TLSv1|SSL_OP_NO_TLSv1_2; minver = TLS1_1_VERSION; maxver = TLS1_1_VERSION; break;
 					case TLSVersion.tls1_2: method = SSLv23_client_method(); veroptions |= SSL_OP_NO_SSLv3|SSL_OP_NO_TLSv1|SSL_OP_NO_TLSv1_1; minver = TLS1_2_VERSION; break;
 					case TLSVersion.dtls1: method = DTLSv1_client_method(); minver = DTLS1_VERSION; maxver = DTLS1_VERSION; break;
@@ -639,11 +637,9 @@ final class OpenSSLContext : TLSContext {
 				final switch (ver) {
 					case TLSVersion.any: method = SSLv23_server_method(); veroptions |= SSL_OP_NO_SSLv3; break;
 					case TLSVersion.ssl3: throw new Exception("SSLv3 is not supported anymore");
-					case TLSVersion.tls1: method = TLSv1_server_method(); veroptions |= SSL_OP_NO_SSLv3; break;
+					case TLSVersion.tls1: method = SSLv23_server_method(); veroptions |= SSL_OP_NO_SSLv3|SSL_OP_NO_TLSv1_1|SSL_OP_NO_TLSv1_2; maxver = TLS1_VERSION; break;
 					case TLSVersion.tls1_1: method = SSLv23_server_method(); veroptions |= SSL_OP_NO_SSLv3|SSL_OP_NO_TLSv1|SSL_OP_NO_TLSv1_2; minver = TLS1_1_VERSION; maxver = TLS1_1_VERSION; break;
 					case TLSVersion.tls1_2: method = SSLv23_server_method(); veroptions |= SSL_OP_NO_SSLv3|SSL_OP_NO_TLSv1|SSL_OP_NO_TLSv1_1; minver = TLS1_2_VERSION; break;
-					//case TLSVersion.tls1_1: method = TLSv1_1_server_method(); break;
-					//case TLSVersion.tls1_2: method = TLSv1_2_server_method(); break;
 					case TLSVersion.dtls1: method = DTLSv1_server_method(); minver = DTLS1_VERSION; maxver = DTLS1_VERSION; break;
 				}
 				options |= SSL_OP_CIPHER_SERVER_PREFERENCE;

--- a/tls/vibe/stream/openssl.d
+++ b/tls/vibe/stream/openssl.d
@@ -625,7 +625,7 @@ final class OpenSSLContext : TLSContext {
 			case TLSContextKind.client:
 				final switch (ver) {
 					case TLSVersion.any: method = SSLv23_client_method(); veroptions |= SSL_OP_NO_SSLv3; break;
-					case TLSVersion.ssl3: method = SSLv23_client_method(); veroptions |= SSL_OP_NO_TLSv1_1|SSL_OP_NO_TLSv1|SSL_OP_NO_TLSv1_2; minver = SSL3_VERSION; maxver = SSL3_VERSION; break;
+					case TLSVersion.ssl3: throw new Exception("SSLv3 is not supported anymore");
 					case TLSVersion.tls1: method = TLSv1_client_method(); veroptions |= SSL_OP_NO_SSLv3; break;
 					//case TLSVersion.tls1_1: method = TLSv1_1_client_method(); break;
 					//case TLSVersion.tls1_2: method = TLSv1_2_client_method(); break;
@@ -638,7 +638,7 @@ final class OpenSSLContext : TLSContext {
 			case TLSContextKind.serverSNI:
 				final switch (ver) {
 					case TLSVersion.any: method = SSLv23_server_method(); veroptions |= SSL_OP_NO_SSLv3; break;
-					case TLSVersion.ssl3: method = SSLv23_server_method(); veroptions |= SSL_OP_NO_TLSv1_1|SSL_OP_NO_TLSv1|SSL_OP_NO_TLSv1_2; minver = SSL3_VERSION; maxver = SSL3_VERSION; break;
+					case TLSVersion.ssl3: throw new Exception("SSLv3 is not supported anymore");
 					case TLSVersion.tls1: method = TLSv1_server_method(); veroptions |= SSL_OP_NO_SSLv3; break;
 					case TLSVersion.tls1_1: method = SSLv23_server_method(); veroptions |= SSL_OP_NO_SSLv3|SSL_OP_NO_TLSv1|SSL_OP_NO_TLSv1_2; minver = TLS1_1_VERSION; maxver = TLS1_1_VERSION; break;
 					case TLSVersion.tls1_2: method = SSLv23_server_method(); veroptions |= SSL_OP_NO_SSLv3|SSL_OP_NO_TLSv1|SSL_OP_NO_TLSv1_1; minver = TLS1_2_VERSION; break;

--- a/tls/vibe/stream/tls.d
+++ b/tls/vibe/stream/tls.d
@@ -335,8 +335,8 @@ enum TLSContextKind {
 }
 
 enum TLSVersion {
-	any, /// Accept SSLv3 or TLSv1.0 and greater
-	ssl3, /// Accept only SSLv3
+	any, /// Accept TLSv1.0 and greater
+	ssl3, /// Accept only SSLv3 (not supported anymore)
 	tls1, /// Accept only TLSv1.0
 	tls1_1, /// Accept only TLSv1.1
 	tls1_2, /// Accept only TLSv1.2


### PR DESCRIPTION
Updates the default cypher suite, removes dysfunctional SSLv3 support and adds a set of tests to check proper TLS version matching between client and server.