### PR TITLE
Fix using URL("...") at compile time.

### DIFF
--- a/inet/vibe/inet/url.d
+++ b/inet/vibe/inet/url.d
@@ -157,9 +157,8 @@ struct URL {
 			str = str[idx+1 .. $];
 			bool requires_host = false;
 
-			if (isCommonInternetSchema(m_schema)) {
+			if (str.startsWith("//")) {
 				// proto://server/path style
-				enforce(str.startsWith("//"), "URL must start with proto://...");
 				requires_host = true;
 				str = str[2 .. $];
 			}


### PR DESCRIPTION
Avoids calling isCommonInternetSchema and instead derives this information from the URL itself. This is possible, because URLs that don't conform to the schema are not allowed to start with "//". See RFC 3986 section 3.3.