### PR TITLE
Improve `vibe.stream.openssl` support for later OpenSSL versions (1.1.1h, 3.0.x)

### DIFF
--- a/tls/vibe/stream/openssl.d
+++ b/tls/vibe/stream/openssl.d
@@ -6,7 +6,9 @@
 	Authors: Sönke Ludwig
 */
 module vibe.stream.openssl;
+
 version(Have_openssl):
+
 import vibe.core.log;
 import vibe.core.net;
 import vibe.core.stream;

--- a/tls/vibe/stream/openssl.d
+++ b/tls/vibe/stream/openssl.d
@@ -71,27 +71,6 @@ enum haveALPN = OPENSSL_VERSION_NUMBER >= 0x10200000 || alpn_forced;
 
 // openssl/1.1.0 hack: provides a 1.0.x API in terms of the 1.1.x API
 static if (OPENSSL_VERSION.startsWith("1.1")) {
-	// this does nothing in > openssl 1.1.0
-	void SSL_load_error_strings() {}
-
-	extern(C)  int OPENSSL_init_ssl(ulong opts, const void* settings);
-
-	// # define SSL_library_init() OPENSSL_init_ssl(0, NULL)
-	int SSL_library_init() {
-		return OPENSSL_init_ssl(0, null);
-	}
-
-	//#  define CRYPTO_num_locks()            (1)
-	int CRYPTO_num_locks() {
-		return 1;
-	}
-
-	void CRYPTO_set_id_callback(T)(T t) {
-	}
-
-	void CRYPTO_set_locking_callback(T)(T t) {
-	}
-
 	// #define SSL_get_ex_new_index(l, p, newf, dupf, freef) \
 	//    CRYPTO_get_ex_new_index(CRYPTO_EX_INDEX_SSL, l, p, newf, dupf, freef)
 
@@ -213,6 +192,34 @@ static if (OPENSSL_VERSION.startsWith("1.0"))
 	private void BIO_set_flags(BIO *b, int flags) @safe nothrow {
 		b.flags |= flags;
 	}
+
+    // The need for calling `CRYPTO_set_id_callback` / `CRYPTO_set_locking_callback`
+    // was removed in OpenSSL 1.1.0, which are the only users of those callbacks
+    // and mutexes.
+    private __gshared InterruptibleTaskMutex[] g_cryptoMutexes;
+
+    private extern(C) c_ulong onCryptoGetThreadID() nothrow @safe
+    {
+        try {
+            return cast(c_ulong)(cast(size_t)() @trusted { return cast(void*)Thread.getThis(); } () * 0x35d2c57);
+        } catch (Exception e) {
+            logWarn("OpenSSL: failed to get current thread ID: %s", e.msg);
+            return 0;
+        }
+    }
+
+    private extern(C) void onCryptoLock(int mode, int n, const(char)* file, int line) nothrow @safe
+    {
+        try {
+            enforce(n >= 0 && n < () @trusted { return g_cryptoMutexes; } ().length, "Mutex index out of range.");
+            auto mutex = () @trusted { return g_cryptoMutexes[n]; } ();
+            assert(mutex !is null);
+            if (mode & CRYPTO_LOCK) mutex.lock();
+            else mutex.unlock();
+        } catch (Exception e) {
+            logWarn("OpenSSL: failed to lock/unlock mutex: %s", e.msg);
+        }
+    }
 }
 
 // Deimos had an incorrect translation for this define prior to 2.0.2+1.1.0h
@@ -1135,30 +1142,35 @@ alias SSLState = ssl_st*;
 /**************************************************************************************************/
 
 private {
-	__gshared InterruptibleTaskMutex[] g_cryptoMutexes;
 	__gshared int gs_verifyDataIndex;
 }
 
 shared static this()
 {
-	logDebug("Initializing OpenSSL...");
-	SSL_load_error_strings();
-	SSL_library_init();
+	static if (OPENSSL_VERSION.startsWith("1.0"))
+	{
+		logDebug("Initializing OpenSSL...");
+		// Not required as of OpenSSL 1.1.0, see:
+		// https://wiki.openssl.org/index.php/Library_Initialization
+		SSL_load_error_strings();
+		SSL_library_init();
 
-	g_cryptoMutexes.length = CRYPTO_num_locks();
-	// TODO: investigate if a normal Mutex is enough - not sure if BIO is called in a locked state
-	foreach (i; 0 .. g_cryptoMutexes.length)
-		g_cryptoMutexes[i] = new InterruptibleTaskMutex;
-	foreach (ref m; g_cryptoMutexes) {
-		assert(m !is null);
+		g_cryptoMutexes.length = CRYPTO_num_locks();
+		// TODO: investigate if a normal Mutex is enough - not sure if BIO is called in a locked state
+		foreach (i; 0 .. g_cryptoMutexes.length)
+			g_cryptoMutexes[i] = new InterruptibleTaskMutex;
+		foreach (ref m; g_cryptoMutexes) {
+			assert(m !is null);
+		}
+
+		// Those two were removed in v1.1.0, see:
+		// https://github.com/openssl/openssl/issues/1260
+		CRYPTO_set_id_callback(&onCryptoGetThreadID);
+		CRYPTO_set_locking_callback(&onCryptoLock);
+		logDebug("... done.");
 	}
 
-	CRYPTO_set_id_callback(&onCryptoGetThreadID);
-	CRYPTO_set_locking_callback(&onCryptoLock);
-
 	enforce(RAND_poll(), "Fatal: failed to initialize random number generator entropy (RAND_poll).");
-	logDebug("... done.");
-
 	gs_verifyDataIndex = SSL_get_ex_new_index(0, cast(void*)"VerifyData".ptr, null, null, null);
 }
 
@@ -1310,29 +1322,6 @@ private nothrow @safe extern(C)
 		}
 
 		return 0;
-	}
-
-	c_ulong onCryptoGetThreadID()
-	{
-		try {
-			return cast(c_ulong)(cast(size_t)() @trusted { return cast(void*)Thread.getThis(); } () * 0x35d2c57);
-		} catch (Exception e) {
-			logWarn("OpenSSL: failed to get current thread ID: %s", e.msg);
-			return 0;
-		}
-	}
-
-	void onCryptoLock(int mode, int n, const(char)* file, int line)
-	{
-		try {
-			enforce(n >= 0 && n < () @trusted { return g_cryptoMutexes; } ().length, "Mutex index out of range.");
-			auto mutex = () @trusted { return g_cryptoMutexes[n]; } ();
-			assert(mutex !is null);
-			if (mode & CRYPTO_LOCK) mutex.lock();
-			else mutex.unlock();
-		} catch (Exception e) {
-			logWarn("OpenSSL: failed to lock/unlock mutex: %s", e.msg);
-		}
 	}
 
 	int onBioNew(BIO *b) nothrow

--- a/tls/vibe/stream/openssl.d
+++ b/tls/vibe/stream/openssl.d
@@ -51,8 +51,12 @@ else
 	static if (__traits(compiles, {import openssl_version; }))
 		mixin("public import openssl_version : OPENSSL_VERSION;");
 	else
-		// try 1.1.0 as softfallback if old other means failed
+	{
+		pragma(msg, __MODULE__, ": Could not detect OpenSSL version - Assuming OpenSSL 1.1.0");
+		pragma(msg, "If you're using dub, make sure pkg-config is installed. ",
+			   "You can also define the version explicitly (see documentation), e.g. VibeUseOpenSSL11");
 		enum OPENSSL_VERSION = "1.1.0";
+	}
 }
 
 version (VibePragmaLib) {

--- a/tls/vibe/stream/openssl.d
+++ b/tls/vibe/stream/openssl.d
@@ -198,6 +198,14 @@ static if (OPENSSL_VERSION.startsWith("1.1")) {
 	}
 }
 
+// Deimos had an incorrect translation for this define prior to 2.0.2+1.1.0h
+// See https://github.com/D-Programming-Deimos/openssl/issues/63#issuecomment-840266138
+static if (!is(typeof(GEN_DNS)))
+{
+	private enum GEN_DNS = GENERAL_NAME.GEN_DNS;
+	private enum GEN_IPADD = GENERAL_NAME.GEN_IPADD;
+}
+
 private int SSL_set_tlsext_host_name(ssl_st* s, const(char)* c) @trusted {
 	return cast(int) SSL_ctrl(s, SSL_CTRL_SET_TLSEXT_HOSTNAME, TLSEXT_NAMETYPE_host_name, cast(void*)c);
 }
@@ -286,7 +294,7 @@ final class OpenSSLStream : TLSStream {
 				readPeerCertInfo();
 				auto result = () @trusted { return SSL_get_verify_result(m_tls); } ();
 				if (result == X509_V_OK && (ctx.peerValidationMode & TLSPeerValidationMode.checkPeer)) {
-					if (!verifyCertName(m_peerCertificate, GENERAL_NAME.GEN_DNS, vdata.peerName)) {
+					if (!verifyCertName(m_peerCertificate, GEN_DNS, vdata.peerName)) {
 						version(Windows) import core.sys.windows.winsock2;
 						else import core.sys.posix.netinet.in_;
 
@@ -305,7 +313,7 @@ final class OpenSSLStream : TLSStream {
 								break;
 						}
 
-						if (!verifyCertName(m_peerCertificate, GENERAL_NAME.GEN_IPADD, () @trusted { return addr[0 .. addrlen]; } ())) {
+						if (!verifyCertName(m_peerCertificate, GEN_IPADD, () @trusted { return addr[0 .. addrlen]; } ())) {
 							logDiagnostic("Error validating TLS peer address");
 							result = X509_V_ERR_APPLICATION_VERIFICATION;
 						}
@@ -1160,12 +1168,12 @@ private bool verifyCertName(X509* cert, int field, in char[] value, bool allow_w
 	int cnid;
 	int alt_type;
 	final switch (field) {
-		case GENERAL_NAME.GEN_DNS:
+		case GEN_DNS:
 			cnid = NID_commonName;
 			alt_type = V_ASN1_IA5STRING;
 			str_match = allow_wildcards ? (in s) => matchWildcard(value, s) : (in s) => s.icmp(value) == 0;
 			break;
-		case GENERAL_NAME.GEN_IPADD:
+		case GEN_IPADD:
 			cnid = 0;
 			alt_type = V_ASN1_OCTET_STRING;
 			str_match = (in s) => s == value;
@@ -1178,7 +1186,7 @@ private bool verifyCertName(X509* cert, int field, in char[] value, bool allow_w
 		foreach (i; 0 .. sk_GENERAL_NAME_num(gens)) {
 			auto gen = sk_GENERAL_NAME_value(gens, i);
 			if (gen.type != field) continue;
-			ASN1_STRING *cstr = field == GENERAL_NAME.GEN_DNS ? gen.d.dNSName : gen.d.iPAddress;
+			ASN1_STRING *cstr = field == GEN_DNS ? gen.d.dNSName : gen.d.iPAddress;
 			if (check_value(cstr, alt_type)) return true;
 		}
 		if (!cnid) return false;


### PR DESCRIPTION
I recently installed Ubuntu 22.04 as my main work machine and Vibe.d didn't build.
Looking more into the module, it's obvious why: The 1.1 support that was added was made in terms of the 1.0 API.
This causes various problems and make it hard to see what piece of code is actually useful.
This is by no mean a full fix, but a good first step (and hopefully inspiration) towards how I believe we can best get there.
Also, as I am on OpenSSL3, it allows me to test that things still work with 1.1 :)