### PR TITLE
Update Deimos OpenSSL bindings to v3.0.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,12 +15,12 @@ jobs:
           - dmd-2.097.1
           - dmd-2.096.1
           - dmd-2.093.1
-          - dmd-2.088.1
+          - dmd-2.090.1
           - ldc-latest
           - ldc-1.27.1
           - ldc-1.26.0
           - ldc-1.23.0
-          - ldc-1.18.0
+          - ldc-1.21.0
         include:
           # Default
           - { parts: 'builds,unittests,examples,tests,mongo', extra_dflags: '' }

--- a/.gitignore
+++ b/.gitignore
@@ -71,5 +71,3 @@ examples/web/web-framework-example
 examples/websocket/websocket-example
 *.exe
 
-# Ignore auto-generated OpenSSL version
-tls/openssl_version.d

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,37 +3,37 @@ environment:
  dub_version: 1.7.2
  matrix:
   - DC: dmd
-    DVersion: 2.098.0
+    DVersion: 2.100.0
     arch: x64
   - DC: dmd
-    DVersion: 2.098.0
+    DVersion: 2.100.0
     arch: x86_mscoff
   - DC: dmd
-    DVersion: 2.092.1
+    DVersion: 2.097.1
     arch: x64
   - DC: dmd
-    DVersion: 2.091.1
+    DVersion: 2.094.1
     arch: x86_mscoff
+  - DC: dmd
+    DVersion: 2.093.1
+    arch: x64
   - DC: dmd
     DVersion: 2.090.1
-    arch: x64
-  - DC: dmd
-    DVersion: 2.088.1
     arch: x86_mscoff
+  - DC: ldc
+    DVersion: 1.29.0
+    arch: x86
   - DC: ldc
     DVersion: 1.28.0
     arch: x86
   - DC: ldc
-    DVersion: 1.21.0
+    DVersion: 1.27.0
+    arch: x64
+  - DC: ldc
+    DVersion: 1.23.0
     arch: x86
   - DC: ldc
     DVersion: 1.20.0
-    arch: x64
-  - DC: ldc
-    DVersion: 1.19.0
-    arch: x86
-  - DC: ldc
-    DVersion: 1.18.0
     arch: x86
 
 branches:

--- a/tls/dub.sdl
+++ b/tls/dub.sdl
@@ -102,9 +102,5 @@ configuration "openssl-1.0" {
 	versions "VibeUseOpenSSL10"
 }
 
-configuration "botan" {
-	dependency "botan" version="~>1.12.0"
-}
-
 configuration "notls" {
 }

--- a/tls/dub.sdl
+++ b/tls/dub.sdl
@@ -14,92 +14,40 @@ copyFiles "../lib/win-amd64/libssl-1_1-x64.dll" "../lib/win-amd64/libcrypto-1_1-
 
 configuration "openssl-mscoff" {
 	platforms "windows-x86_mscoff" "windows-x86_64" "windows-x86-ldc"
-	dependency "openssl" version=">=1.0.0+1.0.0e"
+	dependency "openssl" version="~>3.0"
+	subConfiguration "openssl" "library-manual-version"
+	versions "DeimosOpenSSL_1_1_0"
 	sourceFiles "../lib/win-i386-mscoff/libssl.lib" "../lib/win-i386-mscoff/libcrypto.lib" platform="windows-x86"
 	sourceFiles "../lib/win-amd64/libssl.lib" "../lib/win-amd64/libcrypto.lib" platform="windows-x86_64"
 }
 
 configuration "openssl" {
-	dependency "openssl" version="~>1.0"
-
-	// Windows
-	sourceFiles "../lib/win-i386/libssl.lib" "../lib/win-i386/libcrypto.lib" platform="windows-x86-dmd"
-
-	// Posix
-	preGenerateCommands `echo '
-	/+ dub.sdl:
-	name "script"
-	+/
-	import std.algorithm;
-	import std.conv;
-	import std.file;
-	import std.functional;
-	import std.path;
-	import std.process;
-	import std.range;
-	import std.stdio;
-	import std.string;
-	import std.uni;
-
-	void main()
-	{
-		auto dir = environment.get("DUB_PACKAGE_DIR");
-		if (dir.buildPath("tls").exists)  {
-			dir = dir.buildPath("tls");
-		}
-		string opensslVersion;
-		try {
-			const res = execute(["pkg-config", "openssl", "--modversion"]);
-			if (res.status == 0)
-				opensslVersion = res.output.strip();
-		} catch (Exception e) {}
-
-		if (!opensslVersion.length) try
-		{
-			const res = execute(["openssl", "version"]).output;
-			if (res.canFind("OpenSSL ")) {
-				opensslVersion = res.splitter(" ").dropOne.front.filter!(not!(std.uni.isAlpha)).text;
-			} else if (res.canFind("LibreSSL ")) {
-				writeln("\tWarning: Your default openssl binary points to LibreSSL, which is not supported.");
-				version (OSX) {
-					writeln("\tOn Mac OSX, this is the default behavior.");
-					writeln("\tIf you installed openssl via a package manager, you need to tell DUB how to find it.");
-					writeln("\tAssuming brew, run [brew link openssl] and follow the instructions for pkg-config.\n");
-				}
-			}
-		} catch (Exception e) {}
-		if (!opensslVersion.length)
-		{
-			 writeln("\tWarning: Could not find OpenSSL version via pkg-config nor by calling the openssl binary.");
-			 writeln("\tAssuming version 1.1.0.");
-			 writeln("\tYou might need to export PKG_CONFIG_PATH or install the openssl package if you have a library-only package.");
-			 opensslVersion = "1.1.0";
-		}
-		auto data = text("module openssl_version;\nenum OPENSSL_VERSION=\"", opensslVersion, "\";\n");
-		auto output = dir.buildPath("openssl_version.d");
-		if (!output.exists || output.readText.strip != data.strip)
-			data.toFile(output);
-	}
-	' | ${DUB} - || true` platform="posix"
+	platforms "posix"
+	dependency "openssl" version="~>3.0"
 }
 
 configuration "openssl-1.1" {
 	platforms "posix" "windows"
-	dependency "openssl" version="~>1.0"
-	versions "VibeUseOpenSSL11"
+	dependency "openssl" version="~>3.0"
+	subConfiguration "openssl" "library-manual-version"
+	versions "DeimosOpenSSL_1_1_0"
 	sourceFiles "../lib/win-i386-mscoff/libssl.lib" "../lib/win-i386-mscoff/libcrypto.lib" platform="windows-x86"
 	sourceFiles "../lib/win-amd64/libssl.lib" "../lib/win-amd64/libcrypto.lib" platform="windows-x86_64"
 }
 
 configuration "openssl-1.1-optlink" {
 	platforms "windows-x86-dmd"
+	dependency "openssl" version="~>3.0"
+	subConfiguration "openssl" "library-manual-version"
+	versions "DeimosOpenSSL_1_1_0"
 	sourceFiles "../lib/win-i386/libssl.lib" "../lib/win-i386/libcrypto.lib" platform="windows-x86-dmd"
 }
 
 configuration "openssl-1.0" {
 	platforms "posix"
-	dependency "openssl" version="~>1.0"
-	versions "VibeUseOpenSSL10"
+	dependency "openssl" version="~>3.0"
+	subConfiguration "openssl" "library-manual-version"
+	versions "DeimosOpenSSL_1_0_0"
 }
 
 configuration "notls" {


### PR DESCRIPTION
```
For a long time, the tls subpackage was stuck on OpenSSL bindings v1.x.x.
Those haven't been released for a long time, and the binding's version
did not match OpenSSL. Over time, workarounds were built to support
multiple versions of OpenSSL, but the issue applied to any OpenSSL user,
and the pin to the v1 major version means that a user could not use
the v2 branch and Vibe.d in the same application.
The main improvement that was done downstream was to auto-detect
the OpenSSL version. The script has now been ported to the binding package,
which can now be used by all downstream applications.
The position on multiple version has now been clarified,
and it has been decided that the bindings will now support a range of versions,
with static if / version condition when necessary.

In order for applications to move forward, we now update Vibe.d to depend on this new major version.
This could prove disruptive to end user, but the change is forward compatible,
and should be (almost) a no-op for end users. There is no good transition path here,
as dub does not allow different subconfigurations to depend on different major versions.
```

@s-ludwig : The underlying motivation here is that I want to work with a library that uses v2 of the bindings, and for it to work, we currently use a fork. I'd like to upgrade the whole system to v3 and save everyone some trouble.
This could prove a bit disruptive for those not using the auto-detection, but I think the gains far outweight the cost.

I need to do more tests on this, but I think ultimately, we could just get rid of the different versions, and let the end user (application) define which configuration of openssl to use.