### PR TITLE
Fix issue #2656

### DIFF
--- a/http/vibe/http/status.d
+++ b/http/vibe/http/status.d
@@ -7,10 +7,7 @@
 */
 module vibe.http.status;
 
-/**
-	Definitions of all standard HTTP status codes.
-*/
-enum HTTPStatus {
+enum HTTPStatusBase {
 	continue_                    = 100,
 	switchingProtocols           = 101,
 	ok                           = 200,
@@ -104,6 +101,28 @@ enum HTTPStatus {
 	deprecated("Use `httpVersionNotSupported` instead") HTTPVersionNotSupported = httpVersionNotSupported,
 }
 
+private string buildNonDeprecatedEnum(EnumType)()
+{
+	string result;
+	foreach(m; __traits(allMembers, EnumType))
+	{
+		static if(!__traits(isDeprecated, __traits(getMember, EnumType, m)))
+			result ~= m ~ " = " ~ __traits(identifier, EnumType) ~ "." ~ m ~ ",";
+	}
+	return result;
+}
+
+/**
+	Definitions of all standard HTTP status codes.
+*/
+version(VibeNoDeprecatedEnums)
+{
+	mixin("enum HTTPStatus { ", buildNonDeprecatedEnum!HTTPStatusBase(), " } ");
+}
+else
+{
+	alias HTTPStatus = HTTPStatusBase;
+}
 
 @safe nothrow @nogc pure:
 


### PR DESCRIPTION
By defining VibeNoDeprecatedEnums, the HTTPStatus enum will not have any deprecated members, and deprecations due to trying to format such an enum variable will not spew pages of deprecation spam.

I'm not sure how the doc generator will behave, but it can't be worse than the deprecation spam I got on every build.

Note that this doesn't actually fix the spam for existing build configurations, you still have to define the version.