### PR TITLE
MongoDB 5.1+ driver compatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,10 +41,6 @@ jobs:
           --health-interval 10s
           --health-timeout 5s
           --health-retries 5
-      mongodb:
-        image: mongo
-        ports:
-          - 27017:27017
 
     steps:
     - uses: actions/checkout@v3
@@ -57,7 +53,7 @@ jobs:
     - name: '[POSIX] Run tests'
       env:
         VIBED_DRIVER: vibe-core
-        PARTS: builds,unittests,examples,tests,mongo
+        PARTS: builds,unittests,examples,tests
       run: |
         ./run-ci.sh
 

--- a/.github/workflows/mongo.yml
+++ b/.github/workflows/mongo.yml
@@ -19,7 +19,7 @@ jobs:
         - '6.0'
 
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 10
+    timeout-minutes: 60
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/mongo.yml
+++ b/.github/workflows/mongo.yml
@@ -1,0 +1,53 @@
+name: MongoDB Tests
+
+on: [push, pull_request]
+
+jobs:
+  main:
+    name: Run
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ ubuntu-20.04 ]
+        dc: [ dmd-latest ]
+        mongo:
+        - '3.6'
+        - '4.0'
+        - '4.2'
+        - '4.4'
+        - '5.0'
+        - '6.0'
+
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 10
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Prepare compiler
+      uses: dlang-community/setup-dlang@v1
+      with:
+          compiler: ${{ matrix.dc }}
+
+    - name: variable-mapper
+      uses: kanga333/variable-mapper@v0.2.2
+      with:
+        key: "${{ matrix.mongo }}"
+        map: |
+          {
+            "^3\\.6$": {"MONGO_URL":"https://repo.mongodb.org/apt/ubuntu/dists/bionic/mongodb-org/3.6/multiverse/binary-amd64/mongodb-org-server_3.6.23_amd64.deb"},
+            "^4\\.0$": {"MONGO_URL":"https://repo.mongodb.org/apt/ubuntu/dists/bionic/mongodb-org/4.0/multiverse/binary-amd64/mongodb-org-server_4.0.28_amd64.deb"},
+            "^4\\.2$": {"MONGO_URL":"https://repo.mongodb.org/apt/ubuntu/dists/bionic/mongodb-org/4.2/multiverse/binary-amd64/mongodb-org-server_4.2.22_amd64.deb"},
+            "^4\\.4$": {"MONGO_URL":"https://repo.mongodb.org/apt/ubuntu/dists/focal/mongodb-org/4.4/multiverse/binary-amd64/mongodb-org-server_4.4.16_amd64.deb"},
+            "^5\\.0$": {"MONGO_URL":"https://repo.mongodb.org/apt/ubuntu/dists/focal/mongodb-org/5.0/multiverse/binary-amd64/mongodb-org-server_5.0.12_amd64.deb"},
+            "^6\\.0$": {"MONGO_URL":"https://repo.mongodb.org/apt/ubuntu/dists/focal/mongodb-org/6.0/multiverse/binary-amd64/mongodb-org-server_6.0.1_amd64.deb"}
+          }
+
+    - name: 'Install MongoDB'
+      run: wget "$MONGO_URL" && sudo dpkg -i "$(basename "$MONGO_URL")"
+    - name: 'Run tests'
+      env:
+        VIBED_DRIVER: vibe-core
+        PARTS: mongo
+      run: |
+        ./run-ci.sh

--- a/data/vibe/data/bson.d
+++ b/data/vibe/data/bson.d
@@ -556,7 +556,42 @@ struct Bson {
 	*/
 	string toString()
 	const {
-		return toJson().toString();
+		auto ret = appender!string;
+		toString(ret);
+		return ret.data;
+	}
+
+	void toString(R)(ref R range)
+	const {
+		switch (type)
+		{
+		case Bson.Type.object:
+			// keep ordering of objects
+			range.put("{");
+			bool first = true;
+			foreach (k, v; this.byKeyValue)
+			{
+				if (!first) range.put(",");
+				first = false;
+				range.put(Json(k).toString());
+				range.put(":");
+				v.toString(range);
+			}
+			range.put("}");
+			break;
+		case Bson.Type.array:
+			range.put("[");
+			foreach (i, v; this.byIndexValue)
+			{
+				if (i != 0) range.put(",");
+				v.toString(range);
+			}
+			range.put("]");
+			break;
+		default:
+			range.put(toJson().toString());
+			break;
+		}
 	}
 
 	import std.typecons : Nullable;

--- a/data/vibe/data/bson.d
+++ b/data/vibe/data/bson.d
@@ -565,6 +565,11 @@ struct Bson {
 	const {
 		switch (type)
 		{
+		case Bson.Type.objectID:
+			range.put("ObjectID(");
+			range.put(get!BsonObjectID().toString());
+			range.put(")");
+			break;
 		case Bson.Type.object:
 			// keep ordering of objects
 			range.put("{");

--- a/mongodb/vibe/db/mongo/collection.d
+++ b/mongodb/vibe/db/mongo/collection.d
@@ -139,7 +139,7 @@ struct MongoCollection {
 		foreach (string k, v; serializeToBson(options).byKeyValue)
 			cmd[k] = v;
 		
-		database.runCommand(cmd, true);
+		database.runCommandChecked(cmd);
 		return res;
 	}
 
@@ -168,7 +168,7 @@ struct MongoCollection {
 		foreach (string k, v; serializeToBson(options).byKeyValue)
 			cmd[k] = v;
 		
-		database.runCommand(cmd, true);
+		database.runCommandChecked(cmd);
 		return InsertManyResult(insertedIds);
 	}
 
@@ -231,7 +231,7 @@ struct MongoCollection {
 		}
 		cmd["deletes"] = Bson(deletesBson);
 
-		auto n = database.runCommand(cmd, true)["n"].get!long;
+		auto n = database.runCommandChecked(cmd)["n"].get!long;
 		return DeleteResult(n);
 	}
 
@@ -354,7 +354,7 @@ struct MongoCollection {
 		}
 		cmd["updates"] = Bson(updatesBson);
 
-		auto res = database.runCommand(cmd, true);
+		auto res = database.runCommandChecked(cmd);
 		auto ret = UpdateResult(
 			res["n"].get!long,
 			res["nModified"].get!long,
@@ -493,7 +493,7 @@ struct MongoCollection {
 		cmd.query = query;
 		cmd.update = update;
 		cmd.fields = returnFieldSelector;
-		auto ret = database.runCommand(cmd, true);
+		auto ret = database.runCommandChecked(cmd);
 		return ret["value"];
 	}
 
@@ -532,7 +532,7 @@ struct MongoCollection {
 			cmd[key] = value;
 			return 0;
 		});
-		auto ret = database.runCommand(cmd, true);
+		auto ret = database.runCommandChecked(cmd);
 		return ret["value"];
 	}
 
@@ -555,7 +555,7 @@ struct MongoCollection {
 		Bson cmd = Bson.emptyObject;
 		cmd["count"] = m_name;
 		cmd["query"] = serializeToBson(query);
-		auto reply = database.runCommand(cmd, true);
+		auto reply = database.runCommandChecked(cmd);
 		switch (reply["n"].type) with (Bson.Type) {
 			default: assert(false, "Unsupported data type in BSON reply for COUNT");
 			case double_: return cast(ulong)reply["n"].get!double; // v2.x
@@ -744,7 +744,7 @@ struct MongoCollection {
 
 		import std.algorithm : map;
 
-		auto res = m_db.runCommand(cmd, true);
+		auto res = m_db.runCommandChecked(cmd);
 		static if (is(R == Bson)) return res["values"].byValue;
 		else return res["values"].byValue.map!(b => deserializeBson!R(b));
 	}
@@ -824,7 +824,7 @@ struct MongoCollection {
 		CMD cmd;
 		cmd.dropIndexes = m_name;
 		cmd.index = name;
-		database.runCommand(cmd, true);
+		database.runCommandChecked(cmd);
 	}
 
 	/// ditto
@@ -872,7 +872,7 @@ struct MongoCollection {
 		CMD cmd;
 		cmd.dropIndexes = m_name;
 		cmd.index = "*";
-		database.runCommand(cmd, true);
+		database.runCommandChecked(cmd);
 	}
 
 	/// Unofficial API extension, more efficient multi-index removal on
@@ -889,7 +889,7 @@ struct MongoCollection {
 			CMD cmd;
 			cmd.dropIndexes = m_name;
 			cmd.index = names;
-			database.runCommand(cmd, true);
+			database.runCommandChecked(cmd);
 		} else {
 			foreach (name; names)
 				dropIndex(name);
@@ -988,7 +988,7 @@ struct MongoCollection {
 				indexes ~= index;
 			}
 			cmd["indexes"] = Bson(indexes);
-			database.runCommand(cmd, true);
+			database.runCommandChecked(cmd);
 		} else {
 			foreach (model; models) {
 				// trusted to support old compilers which think opt_dup has
@@ -1050,7 +1050,7 @@ struct MongoCollection {
 
 		CMD cmd;
 		cmd.drop = m_name;
-		database.runCommand(cmd, true);
+		database.runCommandChecked(cmd);
 	}
 }
 

--- a/mongodb/vibe/db/mongo/collection.d
+++ b/mongodb/vibe/db/mongo/collection.d
@@ -678,9 +678,9 @@ struct MongoCollection {
 		}
 		return MongoCursor!R(m_client, cmd,
 			!options.batchSize.isNull ? options.batchSize.get : 0,
-			!options.maxAwaitTimeMS.isNull ? options.maxAwaitTimeMS.get
-				: !options.maxTimeMS.isNull ? options.maxTimeMS.get
-				: long.max);
+			!options.maxAwaitTimeMS.isNull ? options.maxAwaitTimeMS.get.msecs
+				: !options.maxTimeMS.isNull ? options.maxTimeMS.get.msecs
+				: Duration.max);
 	}
 
 	/// Example taken from the MongoDB documentation

--- a/mongodb/vibe/db/mongo/collection.d
+++ b/mongodb/vibe/db/mongo/collection.d
@@ -12,6 +12,7 @@ public import vibe.db.mongo.connection;
 public import vibe.db.mongo.flags;
 
 public import vibe.db.mongo.impl.index;
+public import vibe.db.mongo.impl.crud;
 
 import vibe.core.log;
 import vibe.db.mongo.client;
@@ -78,6 +79,7 @@ struct MongoCollection {
 	  Throws: Exception if a DB communication error occurred.
 	  See_Also: $(LINK http://www.mongodb.org/display/DOCS/Updating)
 	 */
+	deprecated("Use updateOne or updateMany taking UpdateOptions instead, this method breaks in MongoDB 5.1 and onwards.")
 	void update(T, U)(T selector, U update, UpdateFlags flags = UpdateFlags.None)
 	{
 		assert(m_client !is null, "Updating uninitialized MongoCollection.");
@@ -97,6 +99,7 @@ struct MongoCollection {
 	  Throws: Exception if a DB communication error occurred.
 	  See_Also: $(LINK http://www.mongodb.org/display/DOCS/Inserting)
 	 */
+	deprecated("Use the overload taking options, this method breaks in MongoDB 5.1 and onwards.")
 	void insert(T)(T document_or_documents, InsertFlags flags = InsertFlags.None)
 	{
 		assert(m_client !is null, "Inserting into uninitialized MongoCollection.");
@@ -109,34 +112,91 @@ struct MongoCollection {
 	}
 
 	/**
-	  Queries the collection for existing documents.
+		Inserts the provided document(s). If a document is missing an identifier,
+		one is generated automatically by vibe.d.
 
-	  If no arguments are passed to find(), all documents of the collection will be returned.
+		See_Also: $(LINK https://www.mongodb.com/docs/manual/reference/method/db.collection.insertOne/#mongodb-method-db.collection.insertOne)
 
-	  See_Also: $(LINK http://www.mongodb.org/display/DOCS/Querying)
-	 */
+		Standards: $(LINK https://www.mongodb.com/docs/manual/reference/command/insert/)
+	*/
+	InsertOneResult insertOne(T)(T document, InsertOneOptions options = InsertOneOptions.init)
+	{
+		assert(m_client !is null, "Querying uninitialized MongoCollection.");
+
+		Bson cmd = Bson.emptyObject; // empty object because order is important
+		cmd["insert"] = Bson(m_name);
+		auto doc = serializeToBson(document);
+		enforce(doc.type == Bson.Type.object, "Can only insert objects into collections");
+		InsertOneResult res;
+		if ("_id" !in doc.get!(Bson[string]))
+		{
+			doc["_id"] = Bson(res.insertedId = BsonObjectID.generate);
+		}
+		cmd["documents"] = Bson([doc]);
+		MongoConnection conn = m_client.lockConnection();
+		enforceWireVersionConstraints(options, conn.description.maxWireVersion);
+		foreach (string k, v; serializeToBson(options).byKeyValue)
+			cmd[k] = v;
+		
+		database.runCommand(cmd, true);
+		return res;
+	}
+
+	/// ditto
+	InsertOneResult insertMany(T)(T[] documents, InsertManyOptions options = InsertManyOptions.init)
+	{
+		assert(m_client !is null, "Querying uninitialized MongoCollection.");
+
+		Bson cmd = Bson.emptyObject; // empty object because order is important
+		cmd["insert"] = Bson(m_name);
+		Bson[] arr = new Bson[documents.length];
+		BsonObjectID[size_t] insertedIds;
+		foreach (i, document; documents)
+		{
+			auto doc = serializeToBson(document);
+			arr[i] = doc;
+			enforce(doc.type == Bson.Type.object, "Can only insert objects into collections");
+			if ("_id" !in doc.get!(Bson[string]))
+			{
+				doc["_id"] = Bson(insertedIds[i] = BsonObjectID.generate);
+			}
+		}
+		cmd["documents"] = Bson(arr);
+		MongoConnection conn = m_client.lockConnection();
+		enforceWireVersionConstraints(options, conn.description.maxWireVersion);
+		foreach (string k, v; serializeToBson(options).byKeyValue)
+			cmd[k] = v;
+		
+		database.runCommand(cmd, true);
+		return InsertManyResult(insertedIds);
+	}
+
+	deprecated("Use the overload taking FindOptions instead, this method breaks in MongoDB 5.1 and onwards. Note: using a `$query` / `query` member to override the query arguments is no longer supported in the new overload.")
 	MongoCursor!R find(R = Bson, T, U)(T query, U returnFieldSelector, QueryFlags flags = QueryFlags.None, int num_skip = 0, int num_docs_per_chunk = 0)
 	{
 		assert(m_client !is null, "Querying uninitialized MongoCollection.");
 		return MongoCursor!R(m_client, m_fullPath, flags, num_skip, num_docs_per_chunk, query, returnFieldSelector);
 	}
 
-	/// ditto
-	MongoCursor!R find(R = Bson, T)(T query) { return find!R(query, null); }
+	/**
+	  Queries the collection for existing documents.
 
-	/// ditto
-	MongoCursor!R find(R = Bson)() { return find!R(Bson.emptyObject, null); }
+	  If no arguments are passed to find(), all documents of the collection will be returned.
 
-	/** Queries the collection for existing documents.
-
-		Returns:
-			By default, a Bson value of the matching document is returned, or $(D Bson(null))
-			when no document matched. For types R that are not Bson, the returned value is either
-			of type $(D R), or of type $(Nullable!R), if $(D R) is not a reference/pointer type.
-
-		Throws: Exception if a DB communication error or a query error occurred.
-		See_Also: $(LINK http://www.mongodb.org/display/DOCS/Querying)
+	  See_Also: $(LINK http://www.mongodb.org/display/DOCS/Querying)
 	 */
+	MongoCursor!R find(R = Bson, Q)(Q query, FindOptions options)
+	{
+		return MongoCursor!R(m_client, m_fullPath, query, options);
+	}
+
+	/// ditto
+	MongoCursor!R find(R = Bson, Q)(Q query) { return find!R(query, FindOptions.init); }
+
+	/// ditto
+	MongoCursor!R find(R = Bson)() { return find!R(Bson.emptyObject, FindOptions.init); }
+
+	deprecated("Use the overload taking FindOptions instead, this method breaks in MongoDB 5.1 and onwards. Note: using a `$query` / `query` member to override the query arguments is no longer supported in the new overload.")
 	auto findOne(R = Bson, T, U)(T query, U returnFieldSelector, QueryFlags flags = QueryFlags.None)
 	{
 		import std.traits;
@@ -158,8 +218,39 @@ struct MongoCollection {
 			return Nullable!R.init;
 		}
 	}
-	/// ditto
-	auto findOne(R = Bson, T)(T query) { return findOne!R(query, Bson(null)); }
+
+	/** Queries the collection for existing documents.
+
+		Returns:
+			By default, a Bson value of the matching document is returned, or $(D Bson(null))
+			when no document matched. For types R that are not Bson, the returned value is either
+			of type $(D R), or of type $(Nullable!R), if $(D R) is not a reference/pointer type.
+
+		Throws: Exception if a DB communication error or a query error occurred.
+		See_Also: $(LINK http://www.mongodb.org/display/DOCS/Querying)
+	 */
+	auto findOne(R = Bson, T)(T query, FindOptions options = FindOptions.init)
+	{
+		import std.traits;
+		import std.typecons;
+
+		options.limit = 1;
+		auto c = find!R(query, options);
+		static if (is(R == Bson)) {
+			foreach (doc; c) return doc;
+			return Bson(null);
+		} else static if (is(R == class) || isPointer!R || isDynamicArray!R || isAssociativeArray!R) {
+			foreach (doc; c) return doc;
+			return null;
+		} else {
+			foreach (doc; c) {
+				Nullable!R ret;
+				ret = doc;
+				return ret;
+			}
+			return Nullable!R.init;
+		}
+	}
 
 	/**
 	  Removes documents from the collection.
@@ -167,6 +258,7 @@ struct MongoCollection {
 	  Throws: Exception if a DB communication error occurred.
 	  See_Also: $(LINK http://www.mongodb.org/display/DOCS/Removing)
 	 */
+	deprecated("Use deleteOne or deleteMany taking DeleteOptions instead, this method breaks in MongoDB 5.1 and onwards.")
 	void remove(T)(T selector, DeleteFlags flags = DeleteFlags.None)
 	{
 		assert(m_client !is null, "Removing from uninitialized MongoCollection.");
@@ -176,6 +268,7 @@ struct MongoCollection {
 	}
 
 	/// ditto
+	deprecated("Use deleteOne or deleteMany taking DeleteOptions instead, this method breaks in MongoDB 5.1 and onwards.")
 	void remove()() { remove(Bson.emptyObject); }
 
 	/**
@@ -259,31 +352,82 @@ struct MongoCollection {
 		}
 	}
 
-	/**
-		Counts the results of the specified query expression.
+	deprecated("deprecated since MongoDB v4.0, use countDocuments or estimatedDocumentCount instead")
+	alias count = countImpl;
 
-		Throws Exception if a DB communication error occurred.
-		See_Also: $(LINK http://www.mongodb.org/display/DOCS/Advanced+Queries#AdvancedQueries-{{count%28%29}})
-	*/
-	ulong count(T)(T query)
+	private ulong countImpl(T)(T query)
 	{
-		static struct Empty {}
-		static struct CMD {
-			string count;
-			T query;
-			Empty fields;
-		}
-
-		CMD cmd;
-		cmd.count = m_name;
-		cmd.query = query;
-		auto reply = database.runCommand(cmd);
-		enforce(reply["ok"].opt!double == 1 || reply["ok"].opt!int == 1, "Count command failed: "~reply["errmsg"].opt!string);
+		Bson cmd = Bson.emptyObject;
+		cmd["count"] = m_name;
+		cmd["query"] = serializeToBson(query);
+		auto reply = database.runCommand(cmd, true);
 		switch (reply["n"].type) with (Bson.Type) {
 			default: assert(false, "Unsupported data type in BSON reply for COUNT");
 			case double_: return cast(ulong)reply["n"].get!double; // v2.x
 			case int_: return reply["n"].get!int; // v3.x
 			case long_: return reply["n"].get!long; // just in case
+		}
+	}
+
+	/**
+		Returns the count of documents that match the query for a collection or
+		view.
+		
+		The method wraps the `$group` aggregation stage with a `$sum` expression
+		to perform the count.
+
+		Throws Exception if a DB communication error occurred.
+
+		See_Also: $(LINK https://www.mongodb.com/docs/manual/reference/method/db.collection.countDocuments/)
+	*/
+	ulong countDocuments(T)(T filter, CountOptions options = CountOptions.init)
+	{
+		// https://github.com/mongodb/specifications/blob/525dae0aa8791e782ad9dd93e507b60c55a737bb/source/crud/crud.rst#count-api-details
+		Bson[] pipeline = [Bson(["$match": serializeToBson(filter)])];
+		if (!options.skip.isNull)
+			pipeline ~= Bson(["$skip": Bson(options.skip.get)]);
+		if (!options.limit.isNull)
+			pipeline ~= Bson(["$limit": Bson(options.limit.get)]);
+		pipeline ~= Bson(["$group": Bson([
+			"_id": Bson(1),
+			"n": Bson(["$sum": Bson(1)])
+		])]);
+		AggregateOptions aggOptions;
+		foreach (i, field; options.tupleof)
+		{
+			enum name = CountOptions.tupleof[i].stringof;
+			if (name != "filter" && name != "skip" && name != "limit")
+				__traits(getMember, aggOptions, name) = field;
+		}
+		auto reply = aggregate(pipeline, aggOptions).front;
+		return reply["n"].get!long;
+	}
+
+	/**
+		Returns the count of all documents in a collection or view.
+
+		Throws Exception if a DB communication error occurred.
+
+		See_Also: $(LINK https://www.mongodb.com/docs/manual/reference/method/db.collection.estimatedDocumentCount/)
+	*/
+	ulong estimatedDocumentCount(EstimatedDocumentCountOptions options = EstimatedDocumentCountOptions.init)
+	{
+		// https://github.com/mongodb/specifications/blob/525dae0aa8791e782ad9dd93e507b60c55a737bb/source/crud/crud.rst#count-api-details
+		MongoConnection conn = m_client.lockConnection();
+		if (conn.description.satisfiesVersion(WireVersion.v49)) {
+			Bson[] pipeline = [
+				Bson(["$collStats": Bson(["count": Bson.emptyObject])]),
+				Bson(["$group": Bson([
+					"_id": Bson(1),
+					"n": Bson(["$sum": Bson("$count")])
+				])])
+			];
+			AggregateOptions aggOptions;
+			aggOptions.maxTimeMS = options.maxTimeMS;
+			auto reply = aggregate(pipeline, aggOptions).front;
+			return reply["n"].get!long;
+		} else {
+			return countImpl(null);
 		}
 	}
 
@@ -327,6 +471,8 @@ struct MongoCollection {
 		Bson cmd = Bson.emptyObject; // empty object because order is important
 		cmd["aggregate"] = Bson(m_name);
 		cmd["pipeline"] = serializeToBson(pipeline);
+		MongoConnection conn = m_client.lockConnection();
+		enforceWireVersionConstraints(options, conn.description.maxWireVersion);
 		foreach (string k, v; serializeToBson(options).byKeyValue)
 		{
 			// spec recommends to omit cursor field when explain is true
@@ -334,13 +480,11 @@ struct MongoCollection {
 				continue;
 			cmd[k] = v;
 		}
-		auto ret = database.runCommand(cmd, true);
-		R[] existing;
-		static if (is(R == Bson))
-			existing = ret["cursor"]["firstBatch"].get!(Bson[]);
-		else
-			existing = ret["cursor"]["firstBatch"].deserializeBson!(R[]);
-		return MongoCursor!R(m_client, ret["cursor"]["ns"].get!string, ret["cursor"]["id"].get!long, existing);
+		return MongoCursor!R(m_client, cmd,
+			!options.batchSize.isNull ? options.batchSize.get : 0,
+			!options.maxAwaitTimeMS.isNull ? options.maxAwaitTimeMS.get
+				: !options.maxTimeMS.isNull ? options.maxTimeMS.get
+				: long.max);
 	}
 
 	/// Example taken from the MongoDB documentation
@@ -381,26 +525,28 @@ struct MongoCollection {
 		records matching the given query.
 
 		Params:
-			key = Name of the field for which to collect unique values
+			fieldName = Name of the field for which to collect unique values
 			query = The query used to select records
+			options = Options to apply
 
 		Returns:
 			An input range with items of type `R` (`Bson` by default) is
 			returned.
 	*/
-	auto distinct(R = Bson, Q)(string key, Q query)
+	auto distinct(R = Bson, Q)(string fieldName, Q query, DistinctOptions options = DistinctOptions.init)
 	{
-		import std.algorithm : map;
+		assert(m_client !is null, "Querying uninitialized MongoCollection.");
 
-		static struct CMD {
-			string distinct;
-			string key;
-			Q query;
-		}
-		CMD cmd;
-		cmd.distinct = m_name;
-		cmd.key = key;
-		cmd.query = query;
+		Bson cmd = Bson.emptyObject; // empty object because order is important
+		cmd["distinct"] = Bson(m_name);
+		cmd["key"] = Bson(fieldName);
+		cmd["query"] = serializeToBson(query);
+		MongoConnection conn = m_client.lockConnection();
+		enforceWireVersionConstraints(options, conn.description.maxWireVersion);
+		foreach (string k, v; serializeToBson(options).byKeyValue)
+			cmd[k] = v;
+
+		import std.algorithm : map;
 
 		auto res = m_db.runCommand(cmd, true);
 		static if (is(R == Bson)) return res["values"].byValue;
@@ -418,11 +564,11 @@ struct MongoCollection {
 			auto coll = db["collection"];
 
 			coll.drop();
-			coll.insert(["a": "first", "b": "foo"]);
-			coll.insert(["a": "first", "b": "bar"]);
-			coll.insert(["a": "first", "b": "bar"]);
-			coll.insert(["a": "second", "b": "baz"]);
-			coll.insert(["a": "second", "b": "bam"]);
+			coll.insertOne(["a": "first", "b": "foo"]);
+			coll.insertOne(["a": "first", "b": "bar"]);
+			coll.insertOne(["a": "first", "b": "bar"]);
+			coll.insertOne(["a": "second", "b": "baz"]);
+			coll.insertOne(["a": "second", "b": "bam"]);
 
 			auto result = coll.distinct!string("b", ["a": "first"]);
 
@@ -625,7 +771,8 @@ struct MongoCollection {
 		See_Also: $(LINK https://docs.mongodb.com/manual/reference/command/createIndexes/)
 	*/
 	string[] createIndexes(scope const(IndexModel)[] models,
-		CreateIndexesOptions options = CreateIndexesOptions.init)
+		CreateIndexesOptions options = CreateIndexesOptions.init,
+		string file = __FILE__, size_t line = __LINE__)
 	@safe {
 		string[] keys = new string[models.length];
 
@@ -638,7 +785,7 @@ struct MongoCollection {
 				// trusted to support old compilers which think opt_dup has
 				// longer lifetime than model.options
 				IndexOptions opt_dup = (() @trusted => model.options)();
-				enforceWireVersionConstraints(opt_dup, conn.description.maxWireVersion);
+				enforceWireVersionConstraints(opt_dup, conn.description.maxWireVersion, file, line);
 				Bson index = serializeToBson(opt_dup);
 				index["key"] = model.keys;
 				index["name"] = model.name;
@@ -651,13 +798,13 @@ struct MongoCollection {
 				// trusted to support old compilers which think opt_dup has
 				// longer lifetime than model.options
 				IndexOptions opt_dup = (() @trusted => model.options)();
-				enforceWireVersionConstraints(opt_dup, WireVersion.old);
+				enforceWireVersionConstraints(opt_dup, WireVersion.old, file, line);
 				Bson doc = serializeToBson(opt_dup);
 				doc["v"] = 1;
 				doc["key"] = model.keys;
 				doc["ns"] = m_fullPath;
 				doc["name"] = model.name;
-				database["system.indexes"].insert(doc);
+				database["system.indexes"].insertOne(doc);
 			}
 		}
 
@@ -671,17 +818,11 @@ struct MongoCollection {
 	@safe {
 		MongoConnection conn = m_client.lockConnection();
 		if (conn.description.satisfiesVersion(WireVersion.v30)) {
-			static struct CMD {
-				string listIndexes;
-			}
-
-			CMD cmd;
-			cmd.listIndexes = m_name;
-
-			auto reply = database.runCommand(cmd, true);
-			return MongoCursor!R(m_client, reply["cursor"]["ns"].get!string, reply["cursor"]["id"].get!long, reply["cursor"]["firstBatch"].get!(Bson[]));
+			Bson command = Bson.emptyObject;
+			command["listIndexes"] = Bson(m_name);
+			return MongoCursor!R(m_client, command);
 		} else {
-			return database["system.indexes"].find!R();
+			throw new MongoDriverException("listIndexes not supported on MongoDB <3.0");
 		}
 	}
 
@@ -728,11 +869,11 @@ unittest {
 		MongoCollection users = client.getCollection("myapp.users");
 
 		// canonical version using a Bson object
-		users.insert(Bson(["name": Bson("admin"), "password": Bson("secret")]));
+		users.insertOne(Bson(["name": Bson("admin"), "password": Bson("secret")]));
 
 		// short version using a string[string] AA that is automatically
 		// serialized to Bson
-		users.insert(["name": "admin", "password": "secret"]);
+		users.insertOne(["name": "admin", "password": "secret"]);
 
 		// BSON specific types are also serialized automatically
 		auto uid = BsonObjectID.fromString("507f1f77bcf86cd799439011");
@@ -740,7 +881,7 @@ unittest {
 
 		// JSON is another possibility
 		Json jusr = parseJsonString(`{"name": "admin", "password": "secret"}`);
-		users.insert(jusr);
+		users.insertOne(jusr);
 	}
 }
 
@@ -776,7 +917,7 @@ unittest {
 		usr.id = BsonObjectID.generate();
 		usr.loginName = "admin";
 		usr.password = "secret";
-		users.insert(usr);
+		users.insertOne(usr);
 
 		// find supports direct de-serialization of the returned documents
 		foreach (usr2; users.find!User()) {
@@ -810,6 +951,36 @@ struct ReadConcern {
 
 	/// The level of the read concern.
 	string level;
+}
+
+struct WriteConcern {
+	/**
+		If true, wait for the the write operation to get committed to the
+
+		See_Also: $(LINK http://docs.mongodb.org/manual/core/write-concern/#journaled)
+	*/
+	@embedNullable @name("j")
+	Nullable!bool journal;
+
+	/**
+		When an integer, specifies the number of nodes that should acknowledge
+		the write and MUST be greater than or equal to 0.
+
+		When a string, indicates tags. "majority" is defined, but users could
+		specify other custom error modes.
+	*/
+	@embedNullable
+	Nullable!Bson w;
+
+	/**
+		If provided, and the write concern is not satisfied within the specified
+		timeout (in milliseconds), the server will return an error for the
+		operation.
+
+		See_Also: $(LINK http://docs.mongodb.org/manual/core/write-concern/#timeouts)
+	*/
+	@embedNullable @name("wtimeout")
+	Nullable!long wtimeoutMS;
 }
 
 /**
@@ -884,6 +1055,32 @@ struct MinWireVersion
 /// ditto
 MinWireVersion since(WireVersion v) @safe { return MinWireVersion(v); }
 
+/// UDA to warn when a nullable field is set and the server wire version matches
+/// the given version. (inclusive)
+///
+/// Use with $(LREF enforceWireVersionConstraints)
+struct DeprecatedSinceWireVersion
+{
+	///
+	WireVersion v;
+}
+
+/// ditto
+DeprecatedSinceWireVersion deprecatedSince(WireVersion v) @safe { return DeprecatedSinceWireVersion(v); }
+
+/// UDA to throw a MongoException when a nullable field is set and the server
+/// wire version doesn't match the version. (inclusive)
+///
+/// Use with $(LREF enforceWireVersionConstraints)
+struct ErrorBeforeWireVersion
+{
+	///
+	WireVersion v;
+}
+
+/// ditto
+ErrorBeforeWireVersion errorBefore(WireVersion v) @safe { return ErrorBeforeWireVersion(v); }
+
 /// UDA to unset a nullable field if the server wire version is newer than the
 /// given version. (inclusive)
 ///
@@ -897,13 +1094,28 @@ struct MaxWireVersion
 MaxWireVersion until(WireVersion v) @safe { return MaxWireVersion(v); }
 
 /// Unsets nullable fields not matching the server version as defined per UDAs.
-void enforceWireVersionConstraints(T)(ref T field, WireVersion serverVersion)
+void enforceWireVersionConstraints(T)(ref T field, WireVersion serverVersion,
+	string file = __FILE__, size_t line = __LINE__)
 @safe {
 	import std.traits : getUDAs;
+
+	string exception;
 
 	foreach (i, ref v; field.tupleof) {
 		enum minV = getUDAs!(field.tupleof[i], MinWireVersion);
 		enum maxV = getUDAs!(field.tupleof[i], MaxWireVersion);
+		enum deprecateV = getUDAs!(field.tupleof[i], DeprecatedSinceWireVersion);
+		enum errorV = getUDAs!(field.tupleof[i], ErrorBeforeWireVersion);
+
+		static foreach (depr; deprecateV)
+			if (serverVersion >= depr.v && !v.isNull)
+				logInfo("User-set field '%s' is deprecated since MongoDB %s (from %s:%s)",
+					T.tupleof[i].stringof, depr.v, file, line);
+
+		static foreach (err; errorV)
+			if (serverVersion < err.v && !v.isNull)
+				exception ~= format("User-set field '%s' is not supported before MongoDB %s\n",
+					T.tupleof[i].stringof, err.v);
 
 		static foreach (min; minV)
 			if (serverVersion < min.v)
@@ -913,6 +1125,9 @@ void enforceWireVersionConstraints(T)(ref T field, WireVersion serverVersion)
 			if (serverVersion > max.v)
 				v.nullify();
 	}
+
+	if (exception.length)
+		throw new MongoException(exception ~ "from " ~ file ~ ":" ~ line.to!string);
 }
 
 ///
@@ -947,79 +1162,4 @@ unittest
 	enforceWireVersionConstraints(test, WireVersion.v34);
 	assert(!test.a.isNull);
 	assert(test.b.isNull);
-}
-
-/**
-  Represents available options for an aggregate call
-
-  See_Also: $(LINK https://docs.mongodb.com/manual/reference/method/db.collection.aggregate/)
-
-  Standards: $(LINK https://github.com/mongodb/specifications/blob/0c6e56141c867907aacf386e0cbe56d6562a0614/source/crud/crud.rst#api)
- */
-struct AggregateOptions {
-	// non-optional since 3.6
-	// get/set by `batchSize`, undocumented in favor of that field
-	CursorInitArguments cursor;
-
-	/// Specifies the initial batch size for the cursor.
-	ref inout(Nullable!int) batchSize()
-	return @property inout @safe pure nothrow @nogc @ignore {
-		return cursor.batchSize;
-	}
-
-	// undocumented because this field isn't a spec field because it is
-	// out-of-scope for a driver
-	@embedNullable Nullable!bool explain;
-
-	/**
-		Enables writing to temporary files. When set to true, aggregation
-		operations can write data to the _tmp subdirectory in the dbPath
-		directory.
-	*/
-	@embedNullable Nullable!bool allowDiskUse;
-
-	/**
-		Specifies a time limit in milliseconds for processing operations on a
-		cursor. If you do not specify a value for maxTimeMS, operations will not
-		time out.
-	*/
-	@embedNullable Nullable!long maxTimeMS;
-
-	/**
-		If true, allows the write to opt-out of document level validation.
-		This only applies when the $out or $merge stage is specified.
-	*/
-	@embedNullable Nullable!bool bypassDocumentValidation;
-
-	/**
-		Specifies the read concern. Only compatible with a write stage. (e.g.
-		`$out`, `$merge`)
-
-		Aggregate commands do not support the $(D ReadConcern.Level.linearizable)
-		level.
-
-		Standards: $(LINK https://github.com/mongodb/specifications/blob/7745234f93039a83ae42589a6c0cdbefcffa32fa/source/read-write-concern/read-write-concern.rst)
-	*/
-	@embedNullable Nullable!ReadConcern readConcern;
-
-	/// Specifies a collation.
-	@embedNullable Nullable!Collation collation;
-
-	/**
-		The index to use for the aggregation. The index is on the initial
-		collection / view against which the aggregation is run.
-
-		The hint does not apply to $lookup and $graphLookup stages.
-
-		Specify the index either by the index name as a string or the index key
-		pattern. If specified, then the query system will only consider plans
-		using the hinted index.
-	 */
-	@embedNullable Nullable!Bson hint;
-
-	/**
-		Users can specify an arbitrary string to help trace the operation
-		through the database profiler, currentOp, and logs.
-	*/
-	@embedNullable Nullable!string comment;
 }

--- a/mongodb/vibe/db/mongo/collection.d
+++ b/mongodb/vibe/db/mongo/collection.d
@@ -100,7 +100,7 @@ struct MongoCollection {
 	  Throws: Exception if a DB communication error occurred.
 	  See_Also: $(LINK http://www.mongodb.org/display/DOCS/Inserting)
 	 */
-	deprecated("Use the overload taking options, this method breaks in MongoDB 5.1 and onwards.")
+	deprecated("Use the insertOne or insertMany, this method breaks in MongoDB 5.1 and onwards.")
 	void insert(T)(T document_or_documents, InsertFlags flags = InsertFlags.None)
 	{
 		assert(m_client !is null, "Inserting into uninitialized MongoCollection.");
@@ -370,7 +370,7 @@ struct MongoCollection {
 	}
 
 	deprecated("Use the overload taking FindOptions instead, this method breaks in MongoDB 5.1 and onwards. Note: using a `$query` / `query` member to override the query arguments is no longer supported in the new overload.")
-	MongoCursor!R find(R = Bson, T, U)(T query, U returnFieldSelector, QueryFlags flags = QueryFlags.None, int num_skip = 0, int num_docs_per_chunk = 0)
+	MongoCursor!R find(R = Bson, T, U)(T query, U returnFieldSelector, QueryFlags flags, int num_skip = 0, int num_docs_per_chunk = 0)
 	{
 		assert(m_client !is null, "Querying uninitialized MongoCollection.");
 		return MongoCursor!R(m_client, m_db.name, m_name, flags, num_skip, num_docs_per_chunk, query, returnFieldSelector);
@@ -383,19 +383,16 @@ struct MongoCollection {
 
 	  See_Also: $(LINK http://www.mongodb.org/display/DOCS/Querying)
 	 */
-	MongoCursor!R find(R = Bson, Q)(Q query, FindOptions options)
+	MongoCursor!R find(R = Bson, Q)(Q query, FindOptions options = FindOptions.init)
 	{
 		return MongoCursor!R(m_client, m_db.name, m_name, query, options);
 	}
 
 	/// ditto
-	MongoCursor!R find(R = Bson, Q)(Q query) { return find!R(query, FindOptions.init); }
-
-	/// ditto
 	MongoCursor!R find(R = Bson)() { return find!R(Bson.emptyObject, FindOptions.init); }
 
 	deprecated("Use the overload taking FindOptions instead, this method breaks in MongoDB 5.1 and onwards. Note: using a `$query` / `query` member to override the query arguments is no longer supported in the new overload.")
-	auto findOne(R = Bson, T, U)(T query, U returnFieldSelector, QueryFlags flags = QueryFlags.None)
+	auto findOne(R = Bson, T, U)(T query, U returnFieldSelector, QueryFlags flags)
 	{
 		import std.traits;
 		import std.typecons;
@@ -466,7 +463,7 @@ struct MongoCollection {
 	}
 
 	/// ditto
-	deprecated("Use deleteOne or deleteMany taking DeleteOptions instead, this method breaks in MongoDB 5.1 and onwards.")
+	deprecated("Use deleteMany taking DeleteOptions instead, this method breaks in MongoDB 5.1 and onwards.")
 	void remove()() { remove(Bson.emptyObject); }
 
 	/**

--- a/mongodb/vibe/db/mongo/connection.d
+++ b/mongodb/vibe/db/mongo/connection.d
@@ -701,7 +701,7 @@ final class MongoConnection {
 					static if (dupBson)
 						data = recvBsonDup();
 					else
-						data = recvBson(bufsl);
+						data = (() @trusted => recvBson(bufsl))();
 
 					debug (VibeVerboseMongo)
 						logDiagnostic("recvData: sec0[flags=%x]: %s", flagBits, data);
@@ -720,7 +720,7 @@ final class MongoConnection {
 						static if (dupBson)
 							data = recvBsonDup();
 						else
-							data = recvBson(bufsl);
+							data = (() @trusted => recvBson(bufsl))();
 
 						debug (VibeVerboseMongo)
 							logDiagnostic("recvData: sec1[%s]: %s", identifier, data);

--- a/mongodb/vibe/db/mongo/connection.d
+++ b/mongodb/vibe/db/mongo/connection.d
@@ -533,8 +533,14 @@ final class MongoConnection {
 					}
 					break;
 				default:
-					throw new MongoDriverException("Received unexpected payload section type");
+					throw new MongoDriverException("Received unexpected payload section type " ~ payloadType.to!string);
 			}
+		}
+
+		if ((flagBits & (1 << 16)) != 0)
+		{
+			uint crc = recvUInt();
+			// TODO: validate CRC
 		}
 
 		return resid;

--- a/mongodb/vibe/db/mongo/connection.d
+++ b/mongodb/vibe/db/mongo/connection.d
@@ -465,7 +465,7 @@ final class MongoConnection {
 					logDiagnostic("getMore: [db=%s] %s", database, command);
 
 				auto id = sendMsg(-1, 0, command);
-				recvMsg!needsDup(id, (flags, root) @safe {
+				recvMsg!needsDup(id, (flags, scope root) @safe {
 					if (root["ok"].get!double != 1.0)
 						throw new MongoDriverException(formatErrorInfo("getMore failed: "
 							~ root["errmsg"].opt!string("(no message)")));
@@ -550,7 +550,7 @@ final class MongoConnection {
 			logDiagnostic("startFind: %s", command);
 
 		auto id = sendMsg(-1, 0, command);
-		recvMsg!needsDup(id, (flags, root) @safe {
+		recvMsg!needsDup(id, (flags, scope root) @safe {
 			if (root["ok"].get!double != 1.0)
 				throw new MongoDriverException(formatErrorInfo("find failed: "
 					~ root["errmsg"].opt!string("(no message)")));

--- a/mongodb/vibe/db/mongo/connection.d
+++ b/mongodb/vibe/db/mongo/connection.d
@@ -479,7 +479,7 @@ final class MongoConnection {
 						T doc = deserializeBson!T(push);
 						on_doc(doc);
 					}
-				}, (scope ident, size) @safe {}, (scope ident, push) @safe {
+				}, (scope ident, size) @safe {}, (scope ident, scope push) @safe {
 					throw new MongoDriverException(formatErrorInfo("unexpected section type 1 in getMore response"));
 				});
 			}
@@ -564,7 +564,7 @@ final class MongoConnection {
 				T doc = deserializeBson!T(push);
 				on_doc(doc);
 			}
-		}, (scope ident, size) @safe {}, (scope ident, push) @safe {
+		}, (scope ident, size) @safe {}, (scope ident, scope push) @safe {
 			throw new MongoDriverException(formatErrorInfo("unexpected section type 1 in find response"));
 		});
 	}

--- a/mongodb/vibe/db/mongo/connection.d
+++ b/mongodb/vibe/db/mongo/connection.d
@@ -505,8 +505,8 @@ final class MongoConnection {
 		int respto = recvInt();
 		int opcode = recvInt();
 
-		enforce(respto == reqid, "Reply is not for the expected message on a sequential connection!");
-		enforce(opcode == OpCode.Msg, "Got wrong reply type! (must be OP_MSG)");
+		enforce!MongoDriverException(respto == reqid, "Reply is not for the expected message on a sequential connection!");
+		enforce!MongoDriverException(opcode == OpCode.Msg, "Got wrong reply type! (must be OP_MSG)");
 
 		uint flagBits = recvUInt();
 		int sectionLength = cast(int)(msglen - 4 * int.sizeof - flagBits.sizeof);
@@ -560,8 +560,8 @@ final class MongoConnection {
 		int respto = recvInt();
 		int opcode = recvInt();
 
-		enforce(respto == reqid, "Reply is not for the expected message on a sequential connection!");
-		enforce(opcode == OpCode.Reply, "Got a non-'Reply' reply!");
+		enforce!MongoDriverException(respto == reqid, "Reply is not for the expected message on a sequential connection!");
+		enforce!MongoDriverException(opcode == OpCode.Reply, "Got a non-'Reply' reply!");
 
 		auto flags = cast(ReplyFlags)recvInt();
 		long cursor = recvLong();
@@ -678,6 +678,7 @@ final class MongoConnection {
 		ubyte[4] size;
 		recv(size[]);
 		ubyte[] dst = new ubyte[fromBsonData!uint(size)];
+		recv(dst);
 		return Bson(Bson.Type.Object, cast(immutable)dst);
 	}
 	private void recv(ubyte[] dst) { enforce(m_stream); m_stream.read(dst); m_bytesRead += dst.length; }

--- a/mongodb/vibe/db/mongo/connection.d
+++ b/mongodb/vibe/db/mongo/connection.d
@@ -678,7 +678,8 @@ final class MongoConnection {
 		ubyte[4] size;
 		recv(size[]);
 		ubyte[] dst = new ubyte[fromBsonData!uint(size)];
-		recv(dst);
+		dst[0 .. 4] = size;
+		recv(dst[4 .. $]);
 		return Bson(Bson.Type.Object, cast(immutable)dst);
 	}
 	private void recv(ubyte[] dst) { enforce(m_stream); m_stream.read(dst); m_bytesRead += dst.length; }

--- a/mongodb/vibe/db/mongo/connection.d
+++ b/mongodb/vibe/db/mongo/connection.d
@@ -833,6 +833,8 @@ final class MongoConnection {
 		sendValue!int(response_to);
 		sendValue!int(cast(int)OpCode.Msg);
 		sendValue!uint(flagBits);
+		const bool hasCRC = (flagBits & (1 << 16)) != 0;
+		assert(!hasCRC, "sending with CRC bits not yet implemented");
 		sendValue!ubyte(0);
 		sendValue(document);
 		m_outRange.flush();

--- a/mongodb/vibe/db/mongo/connection.d
+++ b/mongodb/vibe/db/mongo/connection.d
@@ -178,8 +178,8 @@ final class MongoConnection {
 
 			m_conn = connectTCP(m_settings.hosts[0].name, m_settings.hosts[0].port, null, 0, connectTimeout);
 			m_conn.tcpNoDelay = true;
-			if (m_settings.socketTimeoutMS)
-				m_conn.readTimeout = m_settings.socketTimeoutMS.msecs;
+			if (m_settings.socketTimeout != Duration.zero)
+				m_conn.readTimeout = m_settings.socketTimeout;
 			if (m_settings.ssl) {
 				auto ctx =  createTLSContext(TLSContextKind.client);
 				if (!m_settings.sslverifycertificate) {

--- a/mongodb/vibe/db/mongo/connection.d
+++ b/mongodb/vibe/db/mongo/connection.d
@@ -746,7 +746,7 @@ final class MongoConnection {
 		cmd["mechanism"] = Bson("SCRAM-SHA-1");
 		cmd["payload"] = Bson(BsonBinData(BsonBinData.Type.generic, payload.representation));
 
-		auto doc = runCommand!Bson(cn, cmd);
+		auto doc = runCommand!(Bson, MongoAuthException)(cn, cmd);
 		string response = cast(string)doc["payload"].get!BsonBinData().rawData;
 		Bson conversationId = doc["conversationId"];
 
@@ -756,7 +756,7 @@ final class MongoConnection {
 		cmd["conversationId"] = conversationId;
 		cmd["payload"] = Bson(BsonBinData(BsonBinData.Type.generic, payload.representation));
 
-		doc = runCommand!Bson(cn, cmd);
+		doc = runCommand!(Bson, MongoAuthException)(cn, cmd);
 		response = cast(string)doc["payload"].get!BsonBinData().rawData;
 
 		payload = state.finalize(response);
@@ -764,7 +764,7 @@ final class MongoConnection {
 		cmd["saslContinue"] = Bson(1);
 		cmd["conversationId"] = conversationId;
 		cmd["payload"] = Bson(BsonBinData(BsonBinData.Type.generic, payload.representation));
-		runCommand!Bson(cn, cmd);
+		runCommand!(Bson, MongoAuthException)(cn, cmd);
 	}
 }
 

--- a/mongodb/vibe/db/mongo/connection.d
+++ b/mongodb/vibe/db/mongo/connection.d
@@ -163,8 +163,9 @@ final class MongoConnection {
 		 * options such as connect timeouts and so on.
 		 */
 		try {
-			m_conn = connectTCP(m_settings.hosts[0].name, m_settings.hosts[0].port);
+			m_conn = connectTCP(m_settings.hosts[0].name, m_settings.hosts[0].port, null, 0, m_settings.connectTimeoutMS.msecs);
 			m_conn.tcpNoDelay = true;
+			m_conn.readTimeout = m_settings.socketTimeoutMS.msecs;
 			if (m_settings.ssl) {
 				auto ctx =  createTLSContext(TLSContextKind.client);
 				if (!m_settings.sslverifycertificate) {

--- a/mongodb/vibe/db/mongo/connection.d
+++ b/mongodb/vibe/db/mongo/connection.d
@@ -553,6 +553,7 @@ final class MongoConnection {
 
 	private void certAuthenticate()
 	{
+		string cn = m_settings.getAuthDatabase ~ ".$cmd";
 		Bson cmd = Bson.emptyObject;
 		cmd["authenticate"] = Bson(1);
 		cmd["mechanism"] = Bson("MONGODB-X509");
@@ -568,7 +569,7 @@ final class MongoConnection {
 
 			cmd["user"] = Bson(m_settings.username);
 		}
-		query!Bson("$external.$cmd", QueryFlags.None, 0, -1, cmd, Bson(null),
+		query!Bson(cn, QueryFlags.None, 0, -1, cmd, Bson(null),
 			(cursor, flags, first_doc, num_docs) {
 				if ((flags & ReplyFlags.QueryFailure) || num_docs != 1)
 					throw new MongoDriverException("Calling authenticate failed.");
@@ -582,7 +583,7 @@ final class MongoConnection {
 
 	private void authenticate()
 	{
-		string cn = (m_settings.database == string.init ? "admin" : m_settings.database) ~ ".$cmd";
+		string cn = m_settings.getAuthDatabase ~ ".$cmd";
 
 		string nonce, key;
 
@@ -621,7 +622,7 @@ final class MongoConnection {
 	private void scramAuthenticate()
 	{
 		import vibe.db.mongo.sasl;
-		string cn = (m_settings.database == string.init ? "admin" : m_settings.database) ~ ".$cmd";
+		string cn = m_settings.getAuthDatabase ~ ".$cmd";
 
 		ScramState state;
 		string payload = state.createInitialRequest(m_settings.username);

--- a/mongodb/vibe/db/mongo/connection.d
+++ b/mongodb/vibe/db/mongo/connection.d
@@ -205,6 +205,8 @@ final class MongoConnection {
 			throw new MongoDriverException(format("Failed to connect to MongoDB server at %s:%s.", m_settings.hosts[0].name, m_settings.hosts[0].port), __FILE__, __LINE__, e);
 		}
 
+		scope (failure) disconnect();
+
 		m_allowReconnect = false;
 		scope (exit)
 			m_allowReconnect = true;
@@ -355,8 +357,6 @@ final class MongoConnection {
 	in(database.length, "runCommand requires a database argument")
 	{
 		import std.array;
-
-		scope (failure) disconnect();
 
 		string formatErrorInfo(string msg) @safe
 		{
@@ -933,6 +933,8 @@ final class MongoConnection {
 
 	private void authenticate()
 	{
+		scope (failure) disconnect();
+	
 		string cn = m_settings.getAuthDatabase;
 
 		auto cmd = Bson(["getnonce": Bson(1)]);

--- a/mongodb/vibe/db/mongo/connection.d
+++ b/mongodb/vibe/db/mongo/connection.d
@@ -376,9 +376,9 @@ final class MongoConnection {
 			Appender!(Bson[])[string] docs;
 			recvMsg!true(id, (flags, root) @safe {
 				ret = root;
-			}, (ident, size) @safe {
+			}, (scope ident, size) @safe {
 				docs[ident] = appender!(Bson[]);
-			}, (ident, push) @safe {
+			}, (scope ident, push) @safe {
 				docs[ident].put(push);
 			});
 
@@ -479,7 +479,7 @@ final class MongoConnection {
 						T doc = deserializeBson!T(push);
 						on_doc(doc);
 					}
-				}, (ident, size) @safe {}, (ident, push) @safe {
+				}, (scope ident, size) @safe {}, (scope ident, push) @safe {
 					throw new MongoDriverException(formatErrorInfo("unexpected section type 1 in getMore response"));
 				});
 			}
@@ -564,7 +564,7 @@ final class MongoConnection {
 				T doc = deserializeBson!T(push);
 				on_doc(doc);
 			}
-		}, (ident, size) @safe {}, (ident, push) @safe {
+		}, (scope ident, size) @safe {}, (scope ident, push) @safe {
 			throw new MongoDriverException(formatErrorInfo("unexpected section type 1 in find response"));
 		});
 	}

--- a/mongodb/vibe/db/mongo/connection.d
+++ b/mongodb/vibe/db/mongo/connection.d
@@ -164,11 +164,16 @@ final class MongoConnection {
 		 * options such as connect timeouts and so on.
 		 */
 		try {
-			import core.time : msecs;
+			import core.time : Duration, msecs;
 
-			m_conn = connectTCP(m_settings.hosts[0].name, m_settings.hosts[0].port, null, 0, m_settings.connectTimeoutMS.msecs);
+			auto connectTimeout = m_settings.connectTimeoutMS.msecs;
+			if (m_settings.connectTimeoutMS == 0)
+				connectTimeout = Duration.max;
+
+			m_conn = connectTCP(m_settings.hosts[0].name, m_settings.hosts[0].port, null, 0, connectTimeout);
 			m_conn.tcpNoDelay = true;
-			m_conn.readTimeout = m_settings.socketTimeoutMS.msecs;
+			if (m_settings.socketTimeoutMS)
+				m_conn.readTimeout = m_settings.socketTimeoutMS.msecs;
 			if (m_settings.ssl) {
 				auto ctx =  createTLSContext(TLSContextKind.client);
 				if (!m_settings.sslverifycertificate) {
@@ -603,7 +608,10 @@ final class MongoConnection {
 		sendValue!ubyte(0);
 		sendValue(document);
 		m_outRange.flush();
-		// logDebugV("Sent mongo opcode %s (id %s) in response to %s with args %s", code, id, response_to, tuple(args));
+		(() @trusted {
+			import std.stdio : stderr;
+			stderr.writefln("Sent mongo msg in response to %s with args %s", id, response_to, flagBits, document);
+		})();
 		return id;
 	}
 

--- a/mongodb/vibe/db/mongo/connection.d
+++ b/mongodb/vibe/db/mongo/connection.d
@@ -543,6 +543,10 @@ final class MongoConnection {
 			// TODO: validate CRC
 		}
 
+		assert(bytes_read + msglen == m_bytesRead,
+			format!"Packet size mismatch! Expected %s bytes, but read %s."(
+				msglen, m_bytesRead - bytes_read));
+
 		return resid;
 	}
 

--- a/mongodb/vibe/db/mongo/connection.d
+++ b/mongodb/vibe/db/mongo/connection.d
@@ -358,7 +358,7 @@ final class MongoConnection {
 
 		scope (failure) disconnect();
 
-		string formatErrorInfo(string msg)
+		string formatErrorInfo(string msg) @safe
 		{
 			return text(msg, " in ", errorInfo, " (", errorFile, ":", errorLine, ")");
 		}
@@ -374,11 +374,11 @@ final class MongoConnection {
 
 			auto id = sendMsg(-1, 0, command);
 			Appender!(Bson[])[string] docs;
-			recvMsg!true(id, (flags, root) {
+			recvMsg!true(id, (flags, root) @safe {
 				ret = root;
-			}, (ident, size) {
+			}, (ident, size) @safe {
 				docs[ident] = appender!(Bson[]);
-			}, (ident, push) {
+			}, (ident, push) @safe {
 				docs[ident].put(push);
 			});
 
@@ -450,7 +450,7 @@ final class MongoConnection {
 			if (timeout != Duration.max && timeout.total!"msecs" < int.max)
 				command["maxTimeMS"] = Bson(cast(int)timeout.total!"msecs");
 
-			string formatErrorInfo(string msg)
+			string formatErrorInfo(string msg) @safe
 			{
 				return text(msg, " in ", errorInfo, " (", errorFile, ":", errorLine, ")");
 			}
@@ -465,7 +465,7 @@ final class MongoConnection {
 					logDiagnostic("getMore: [db=%s] %s", database, command);
 
 				auto id = sendMsg(-1, 0, command);
-				recvMsg!needsDup(id, (flags, root) {
+				recvMsg!needsDup(id, (flags, root) @safe {
 					if (root["ok"].get!double != 1.0)
 						throw new MongoDriverException(formatErrorInfo("getMore failed: "
 							~ root["errmsg"].opt!string("(no message)")));
@@ -479,7 +479,7 @@ final class MongoConnection {
 						T doc = deserializeBson!T(push);
 						on_doc(doc);
 					}
-				}, (ident, size) {}, (ident, push) {
+				}, (ident, size) @safe {}, (ident, push) @safe {
 					throw new MongoDriverException(formatErrorInfo("unexpected section type 1 in getMore response"));
 				});
 			}
@@ -535,7 +535,7 @@ final class MongoConnection {
 		scope GetMoreDocumentDelegate!T on_doc,
 		string errorInfo = __FUNCTION__, string errorFile = __FILE__, size_t errorLine = __LINE__)
 	{
-		string formatErrorInfo(string msg)
+		string formatErrorInfo(string msg) @safe
 		{
 			return text(msg, " in ", errorInfo, " (", errorFile, ":", errorLine, ")");
 		}
@@ -550,7 +550,7 @@ final class MongoConnection {
 			logDiagnostic("startFind: %s", command);
 
 		auto id = sendMsg(-1, 0, command);
-		recvMsg!needsDup(id, (flags, root) {
+		recvMsg!needsDup(id, (flags, root) @safe {
 			if (root["ok"].get!double != 1.0)
 				throw new MongoDriverException(formatErrorInfo("find failed: "
 					~ root["errmsg"].opt!string("(no message)")));
@@ -564,7 +564,7 @@ final class MongoConnection {
 				T doc = deserializeBson!T(push);
 				on_doc(doc);
 			}
-		}, (ident, size) {}, (ident, push) {
+		}, (ident, size) @safe {}, (ident, push) @safe {
 			throw new MongoDriverException(formatErrorInfo("unexpected section type 1 in find response"));
 		});
 	}

--- a/mongodb/vibe/db/mongo/cursor.d
+++ b/mongodb/vibe/db/mongo/cursor.d
@@ -448,7 +448,8 @@ private class MongoFindCursor(DocType) : IMongoCursorData!DocType {
 
 	final @property long index()
 	@safe {
-		return m_totalReceived + m_readDoc;
+		assert(m_totalReceived >= m_documents.length);
+		return m_totalReceived - m_documents.length + m_readDoc;
 	}
 
 	final @property DocType front()

--- a/mongodb/vibe/db/mongo/cursor.d
+++ b/mongodb/vibe/db/mongo/cursor.d
@@ -98,9 +98,9 @@ struct MongoCursor(DocType = Bson) {
 
 		this(client, command,
 			options.batchSize.isNull ? 0 : options.batchSize.get,
-			!options.maxAwaitTimeMS.isNull ? options.maxAwaitTimeMS.get
-				: allowMaxTime && !options.maxTimeMS.isNull ? options.maxTimeMS.get
-				: long.max);
+			!options.maxAwaitTimeMS.isNull ? options.maxAwaitTimeMS.get.msecs
+				: allowMaxTime && !options.maxTimeMS.isNull ? options.maxTimeMS.get.msecs
+				: Duration.max);
 	}
 
 	this(MongoClient client, Bson command, int batchSize = 0, Duration getMoreMaxTime = Duration.max)

--- a/mongodb/vibe/db/mongo/database.d
+++ b/mongodb/vibe/db/mongo/database.d
@@ -158,6 +158,7 @@ struct MongoDatabase
 			cmd = command_and_options;
 		else
 			cmd = command_and_options.serializeToBson;
+		cmd["$db"] = Bson(m_name);
 
 		return MongoCursor!R(m_client, cmd, batchSize, getMoreMaxTimeMS);
 	}

--- a/mongodb/vibe/db/mongo/database.d
+++ b/mongodb/vibe/db/mongo/database.d
@@ -160,6 +160,6 @@ struct MongoDatabase
 		static if (is(R == Bson))
 			auto existing = cur["cursor"]["firstBatch"].get!(Bson[]);
 		else auto existing = cur["cursor"]["firstBatch"].deserializeBson!(R[]);
-		return MongoCursor!R(m_client, m_commandCollection, cursorid, existing);
+		return MongoCursor!R(m_client, m_name ~ ".$cmd", cursorid, existing);
 	}
 }

--- a/mongodb/vibe/db/mongo/database.d
+++ b/mongodb/vibe/db/mongo/database.d
@@ -140,7 +140,7 @@ struct MongoDatabase
 		return runCommand(command_and_options, false, errorInfo, errorFile, errorLine);
 	}
 	/// ditto
-	Bson runCommand(T)(T command_and_options, bool checkOk,
+	Bson runCommand(T, ExceptionT = MongoDriverException)(T command_and_options, bool checkOk,
 		string errorInfo = __FUNCTION__, string errorFile = __FILE__, size_t errorLine = __LINE__)
 	{
 		Bson cmd;
@@ -148,7 +148,7 @@ struct MongoDatabase
 			cmd = command_and_options;
 		else
 			cmd = command_and_options.serializeToBson;
-		return m_client.lockConnection().runCommand!(Bson, MongoException)(m_name, cmd, checkOk, errorInfo, errorFile, errorLine);
+		return m_client.lockConnection().runCommand!(Bson, ExceptionT)(m_name, cmd, checkOk, errorInfo, errorFile, errorLine);
 	}
 	/// ditto
 	MongoCursor!R runListCommand(R = Bson, T)(T command_and_options, int batchSize = 0, long getMoreMaxTimeMS = long.max)

--- a/mongodb/vibe/db/mongo/database.d
+++ b/mongodb/vibe/db/mongo/database.d
@@ -14,6 +14,7 @@ import vibe.db.mongo.client;
 import vibe.db.mongo.collection;
 import vibe.data.bson;
 
+import core.time;
 
 /** Represents a single database accessible through a given MongoClient.
 */
@@ -175,7 +176,7 @@ struct MongoDatabase
 	}
 
 	/// ditto
-	MongoCursor!R runListCommand(R = Bson, T)(T command_and_options, int batchSize = 0, long getMoreMaxTimeMS = long.max)
+	MongoCursor!R runListCommand(R = Bson, T)(T command_and_options, int batchSize = 0, Duration getMoreMaxTime = Duration.max)
 	{
 		Bson cmd;
 		static if (is(T : Bson))
@@ -184,6 +185,6 @@ struct MongoDatabase
 			cmd = command_and_options.serializeToBson;
 		cmd["$db"] = Bson(m_name);
 
-		return MongoCursor!R(m_client, cmd, batchSize, getMoreMaxTimeMS);
+		return MongoCursor!R(m_client, cmd, batchSize, getMoreMaxTime);
 	}
 }

--- a/mongodb/vibe/db/mongo/flags.d
+++ b/mongodb/vibe/db/mongo/flags.d
@@ -8,52 +8,7 @@
 module vibe.db.mongo.flags;
 
 deprecated public import vibe.db.mongo.impl.index : IndexFlags;
-
-enum UpdateFlags {
-	none         = 0,    /// Normal update of a single document.
-	upsert       = 1<<0, /// Creates a document if none exists.
-	multiUpdate  = 1<<1, /// Updates all matching documents.
-
-	None = none, /// Deprecated compatibility alias
-	Upsert = upsert, /// Deprecated compatibility alias
-	MultiUpdate = multiUpdate /// Deprecated compatibility alias
-}
-
-enum InsertFlags {
-	none             = 0,    /// Normal insert.
-	continueOnError  = 1<<0, /// For multiple inserted documents, continues inserting further documents after a failure.
-
-	None = none, /// Deprecated compatibility alias
-	ContinueOnError = continueOnError /// Deprecated compatibility alias
-}
-
-enum QueryFlags {
-	none             = 0,    /// Normal query
-	tailableCursor   = 1<<1, ///
-	slaveOk          = 1<<2, ///
-	oplogReplay      = 1<<3, ///
-	noCursorTimeout  = 1<<4, ///
-	awaitData        = 1<<5, ///
-	exhaust          = 1<<6, ///
-	partial          = 1<<7, ///
-
-	None = none, /// Deprecated compatibility alias
-	TailableCursor = tailableCursor, /// Deprecated compatibility alias
-	SlaveOk = slaveOk, /// Deprecated compatibility alias
-	OplogReplay = oplogReplay, /// Deprecated compatibility alias
-	NoCursorTimeout = noCursorTimeout, /// Deprecated compatibility alias
-	AwaitData = awaitData, /// Deprecated compatibility alias
-	Exhaust = exhaust, /// Deprecated compatibility alias
-	Partial = partial /// Deprecated compatibility alias
-}
-
-enum DeleteFlags {
-	none          = 0,
-	singleRemove  = 1<<0,
-
-	None = none, /// Deprecated compatibility alias
-	SingleRemove = singleRemove /// Deprecated compatibility alias
-}
+deprecated public import vibe.db.mongo.impl.crud : UpdateFlags, InsertFlags, QueryFlags, DeleteFlags;
 
 enum ReplyFlags {
 	none              = 0,

--- a/mongodb/vibe/db/mongo/impl/crud.d
+++ b/mongodb/vibe/db/mongo/impl/crud.d
@@ -1,0 +1,875 @@
+module vibe.db.mongo.impl.crud;
+
+import core.time;
+
+import vibe.db.mongo.collection;
+import vibe.data.bson;
+
+import std.typecons;
+
+@safe:
+
+enum UpdateFlags {
+	none         = 0,    /// Normal update of a single document.
+	upsert       = 1<<0, /// Creates a document if none exists.
+	multiUpdate  = 1<<1, /// Updates all matching documents.
+
+	None = none, /// Deprecated compatibility alias
+	Upsert = upsert, /// Deprecated compatibility alias
+	MultiUpdate = multiUpdate /// Deprecated compatibility alias
+}
+
+enum InsertFlags {
+	none             = 0,    /// Normal insert.
+	continueOnError  = 1<<0, /// For multiple inserted documents, continues inserting further documents after a failure.
+
+	None = none, /// Deprecated compatibility alias
+	ContinueOnError = continueOnError /// Deprecated compatibility alias
+}
+
+deprecated("Use FindOptions instead")
+enum QueryFlags {
+	none             = 0,    /// Normal query
+	tailableCursor   = 1<<1, ///
+	slaveOk          = 1<<2, ///
+	oplogReplay      = 1<<3, ///
+	noCursorTimeout  = 1<<4, ///
+	awaitData        = 1<<5, ///
+	exhaust          = 1<<6, ///
+	partial          = 1<<7, ///
+
+	None = none, /// Deprecated compatibility alias
+	TailableCursor = tailableCursor, /// Deprecated compatibility alias
+	SlaveOk = slaveOk, /// Deprecated compatibility alias
+	OplogReplay = oplogReplay, /// Deprecated compatibility alias
+	NoCursorTimeout = noCursorTimeout, /// Deprecated compatibility alias
+	AwaitData = awaitData, /// Deprecated compatibility alias
+	Exhaust = exhaust, /// Deprecated compatibility alias
+	Partial = partial /// Deprecated compatibility alias
+}
+
+enum DeleteFlags {
+	none          = 0,
+	singleRemove  = 1<<0,
+
+	None = none, /// Deprecated compatibility alias
+	SingleRemove = singleRemove /// Deprecated compatibility alias
+}
+
+/**
+	See_Also: $(LINK https://docs.mongodb.com/manual/reference/command/find/)
+
+	Standards: $(LINK https://github.com/mongodb/specifications/blob/525dae0aa8791e782ad9dd93e507b60c55a737bb/source/crud/crud.rst#id16)
+*/
+struct FindOptions
+{
+	/**
+		Enables writing to temporary files on the server. When set to true, the server
+		can write temporary data to disk while executing the find operation.
+
+		This option is only supported by servers >= 4.4.
+	*/
+	@embedNullable @errorBefore(WireVersion.v44)
+	Nullable!bool allowDiskUse;
+
+	/**
+		Get partial results from a mongos if some shards are down (instead of throwing an error).
+	*/
+	@embedNullable
+	Nullable!bool allowPartialResults;
+
+	/**
+		The number of documents to return per batch.
+	*/
+	@embedNullable
+	Nullable!int batchSize;
+
+	/**
+		Determines whether to close the cursor after the first batch.
+
+		Set automatically if limit < 0 || batchSize < 0.
+	*/
+	@embedNullable
+	package Nullable!bool singleBatch;
+
+	/**
+		Collation allows users to specify language-specific rules for string
+		comparison, such as rules for letter-case and accent marks.
+	*/
+	@embedNullable @errorBefore(WireVersion.v34)
+	Nullable!Collation collation;
+
+	/**
+		Users can specify an arbitrary string to help trace the operation
+		through the database profiler, currentOp, and logs.
+	*/
+	@embedNullable
+	Nullable!string comment;
+
+	/**
+		Indicates the type of cursor to use. This value includes both
+		the tailable and awaitData options.
+	*/
+	@ignore CursorType cursorType;
+
+	/**
+		The index to use. Specify either the index name as a string or the index
+		key pattern.
+
+		If specified, then the query system will only consider plans using the
+		hinted index.
+	*/
+	@embedNullable
+	Nullable!Bson hint;
+
+	/**
+		The maximum number of documents to return.
+
+		A negative limit only returns a single batch of results.
+	*/
+	@embedNullable
+	Nullable!long limit;
+
+	/**
+		The exclusive upper bound for a specific index.
+	*/
+	@embedNullable
+	Nullable!Bson max;
+
+	/**
+		The maximum amount of time for the server to wait on new documents to
+		satisfy a tailable cursor query. This only applies to a TAILABLE_AWAIT
+		cursor. When the cursor is not a TAILABLE_AWAIT cursor, this option is
+		ignored.
+		
+		Note: This option is specified as "maxTimeMS" in the getMore command and
+		not provided as part of the initial find command.
+	*/
+	@embedNullable @since(WireVersion.v32)
+	Nullable!long maxAwaitTimeMS;
+
+	/// ditto
+	void maxAwaitTime(Duration d)
+	@safe {
+		maxAwaitTimeMS = cast(long)d.total!"msecs";
+	}
+
+	/**
+		Maximum number of documents or index keys to scan when executing the query.
+	*/
+	@embedNullable @deprecatedSince(WireVersion.v40)
+	Nullable!long maxScan;
+
+	/**
+		The maximum amount of time to allow the query to run.
+	*/
+	@embedNullable
+	Nullable!long maxTimeMS;
+
+	/// ditto
+	void maxTime(Duration d)
+	@safe {
+		maxTimeMS = cast(long)d.total!"msecs";
+	}
+
+	/**
+		The exclusive lower bound for a specific index.
+	*/
+	@embedNullable
+	Nullable!Bson min;
+
+	/**
+		The server normally times out idle cursors after an inactivity period
+		(10 minutes) to prevent excess memory use. Set this option to prevent
+		that.
+	*/
+	@embedNullable
+	Nullable!bool noCursorTimeout;
+
+	/**
+		Enables optimization when querying the oplog for a range of ts values.
+
+		Note: this option is intended for internal replication use only.
+	*/
+	@embedNullable @deprecatedSince(WireVersion.v44)
+	Nullable!bool oplogReplay;
+
+	/**
+		Limits the fields to return for all matching documents.
+	*/
+	@embedNullable
+	Nullable!Bson projection;
+
+	/**
+		If true, returns only the index keys in the resulting documents.
+	*/
+	@embedNullable
+	Nullable!bool returnKey;
+
+	/**
+		Determines whether to return the record identifier for each document. If
+		true, adds a field $recordId to the returned documents.
+	*/
+	@embedNullable
+	Nullable!bool showRecordId;
+
+	/**
+		The number of documents to skip before returning.
+	*/
+	@embedNullable
+	Nullable!long skip;
+
+	/**
+		Prevents the cursor from returning a document more than once because of
+		an intervening write operation.
+	*/
+	@embedNullable @deprecatedSince(WireVersion.v40)
+	Nullable!bool snapshot;
+
+	/**
+		The order in which to return matching documents.
+	*/
+	@embedNullable
+	Nullable!Bson sort;
+
+	/**
+		Specifies the read concern. Only compatible with a write stage. (e.g.
+		`$out`, `$merge`)
+
+		Aggregate commands do not support the $(D ReadConcern.Level.linearizable)
+		level.
+
+		Standards: $(LINK https://github.com/mongodb/specifications/blob/7745234f93039a83ae42589a6c0cdbefcffa32fa/source/read-write-concern/read-write-concern.rst)
+	*/
+	@embedNullable Nullable!ReadConcern readConcern;
+}
+
+///
+enum CursorType
+{
+	/**
+		The default value. A vast majority of cursors will be of this type.
+	*/
+	nonTailable,
+	/**
+		Tailable means the cursor is not closed when the last data is retrieved.
+		Rather, the cursor marks the final object’s position. You can resume
+		using the cursor later, from where it was located, if more data were
+		received. Like any “latent cursor”, the cursor may become invalid at
+		some point (CursorNotFound) – for example if the final object it
+		references were deleted.
+	*/
+	tailable,
+	/**
+		Combines the tailable option with awaitData, as defined below.
+
+		Use with TailableCursor. If we are at the end of the data, block for a
+		while rather than returning no data. After a timeout period, we do
+		return as normal. The default is true.
+	*/
+	tailableAwait,
+}
+
+/**
+	See_Also: $(LINK https://www.mongodb.com/docs/manual/reference/command/distinct/)
+
+	Standards: $(LINK https://github.com/mongodb/specifications/blob/525dae0aa8791e782ad9dd93e507b60c55a737bb/source/crud/crud.rst#id16)
+*/
+struct DistinctOptions
+{
+	/**
+		Collation allows users to specify language-specific rules for string
+		comparison, such as rules for letter-case and accent marks.
+	*/
+	@embedNullable @errorBefore(WireVersion.v34)
+	Nullable!Collation collation;
+
+	/**
+		The maximum amount of time to allow the query to run.
+	*/
+	@embedNullable
+	Nullable!long maxTimeMS;
+
+	/// ditto
+	void maxTime(Duration d)
+	@safe {
+		maxTimeMS = cast(long)d.total!"msecs";
+	}
+
+	/**
+		Specifies the read concern. Only compatible with a write stage. (e.g.
+		`$out`, `$merge`)
+
+		Aggregate commands do not support the $(D ReadConcern.Level.linearizable)
+		level.
+
+		Standards: $(LINK https://github.com/mongodb/specifications/blob/7745234f93039a83ae42589a6c0cdbefcffa32fa/source/read-write-concern/read-write-concern.rst)
+	*/
+	@embedNullable Nullable!ReadConcern readConcern;
+
+	/**
+		Users can specify an arbitrary string to help trace the operation
+		through the database profiler, currentOp, and logs.
+	*/
+	@embedNullable
+	Nullable!string comment;
+}
+
+/**
+	See_Also: $(LINK https://www.mongodb.com/docs/manual/reference/command/count/)
+		  and $(LINK https://www.mongodb.com/docs/manual/reference/method/db.collection.countDocuments/)
+
+	Standards: $(LINK https://github.com/mongodb/specifications/blob/525dae0aa8791e782ad9dd93e507b60c55a737bb/source/crud/crud.rst#id16)
+*/
+struct CountOptions
+{
+	/**
+		Collation allows users to specify language-specific rules for string
+		comparison, such as rules for letter-case and accent marks.
+	*/
+	@embedNullable @errorBefore(WireVersion.v34)
+	Nullable!Collation collation;
+
+	/**
+		The index to use. Specify either the index name as a string or the index
+		key pattern.
+
+		If specified, then the query system will only consider plans using the
+		hinted index.
+	*/
+	@embedNullable
+	Nullable!Bson hint;
+
+	/**
+		The maximum number of documents to return.
+
+		A negative limit only returns a single batch of results.
+	*/
+	@embedNullable
+	Nullable!long limit;
+
+	/**
+		The maximum amount of time to allow the query to run.
+	*/
+	@embedNullable
+	Nullable!long maxTimeMS;
+
+	/// ditto
+	void maxTime(Duration d)
+	@safe {
+		maxTimeMS = cast(long)d.total!"msecs";
+	}
+
+	/**
+		The number of documents to skip before returning.
+	*/
+	@embedNullable
+	Nullable!long skip;
+
+	/**
+		Specifies the read concern. Only compatible with a write stage. (e.g.
+		`$out`, `$merge`)
+
+		Aggregate commands do not support the $(D ReadConcern.Level.linearizable)
+		level.
+
+		Standards: $(LINK https://github.com/mongodb/specifications/blob/7745234f93039a83ae42589a6c0cdbefcffa32fa/source/read-write-concern/read-write-concern.rst)
+	*/
+	@embedNullable Nullable!ReadConcern readConcern;
+}
+
+/**
+	See_Also: $(LINK https://www.mongodb.com/docs/manual/reference/method/db.collection.estimatedDocumentCount/)
+
+	Standards: $(LINK https://github.com/mongodb/specifications/blob/525dae0aa8791e782ad9dd93e507b60c55a737bb/source/crud/crud.rst#id16)
+*/
+struct EstimatedDocumentCountOptions
+{
+	/**
+		The maximum amount of time to allow the query to run.
+	*/
+	@embedNullable
+	Nullable!long maxTimeMS;
+
+	/// ditto
+	void maxTime(Duration d)
+	@safe {
+		maxTimeMS = cast(long)d.total!"msecs";
+	}
+}
+
+/**
+	Represents available options for an aggregate call
+
+	See_Also: $(LINK https://www.mongodb.com/docs/manual/reference/command/aggregate/#dbcmd.aggregate)
+
+	Standards: $(LINK https://github.com/mongodb/specifications/blob/525dae0aa8791e782ad9dd93e507b60c55a737bb/source/crud/crud.rst#id16)
+*/
+struct AggregateOptions
+{
+	// undocumented because this field isn't a spec field because it is
+	// out-of-scope for a driver
+	@embedNullable Nullable!bool explain;
+
+	/**
+		Enables writing to temporary files. When set to true, aggregation
+		operations can write data to the _tmp subdirectory in the dbPath
+		directory.
+	*/
+	@embedNullable
+	Nullable!bool allowDiskUse;
+
+	// non-optional since 3.6
+	// get/set by `batchSize`, undocumented in favor of that field
+	CursorInitArguments cursor;
+
+	/// Specifies the initial batch size for the cursor.
+	ref inout(Nullable!int) batchSize()
+	return @property inout @safe pure nothrow @nogc @ignore {
+		return cursor.batchSize;
+	}
+
+	/**
+		If true, allows the write to opt-out of document level validation.
+		This only applies when the $out or $merge stage is specified.
+	*/
+	@embedNullable @since(WireVersion.v32)
+	Nullable!bool bypassDocumentValidation;
+
+	/**
+		Collation allows users to specify language-specific rules for string
+		comparison, such as rules for letter-case and accent marks.
+	*/
+	@embedNullable @errorBefore(WireVersion.v34)
+	Nullable!Collation collation;
+
+	/**
+		Users can specify an arbitrary string to help trace the operation
+		through the database profiler, currentOp, and logs.
+	*/
+	@embedNullable
+	Nullable!string comment;
+
+	/**
+		The maximum amount of time for the server to wait on new documents to
+		satisfy a tailable cursor query. This only applies to a TAILABLE_AWAIT
+		cursor. When the cursor is not a TAILABLE_AWAIT cursor, this option is
+		ignored.
+		
+		Note: This option is specified as "maxTimeMS" in the getMore command and
+		not provided as part of the initial find command.
+	*/
+	@embedNullable @since(WireVersion.v32)
+	Nullable!long maxAwaitTimeMS;
+
+	/// ditto
+	void maxAwaitTime(Duration d)
+	@safe {
+		maxAwaitTimeMS = cast(long)d.total!"msecs";
+	}
+
+	/**
+		Specifies a time limit in milliseconds for processing operations on a
+		cursor. If you do not specify a value for maxTimeMS, operations will not
+		time out.
+	*/
+	@embedNullable
+	Nullable!long maxTimeMS;
+
+	/// ditto
+	void maxTime(Duration d)
+	@safe {
+		maxTimeMS = cast(long)d.total!"msecs";
+	}
+
+	/**
+		The index to use for the aggregation. The index is on the initial
+		collection / view against which the aggregation is run.
+
+		The hint does not apply to $lookup and $graphLookup stages.
+
+		Specify the index either by the index name as a string or the index key
+		pattern. If specified, then the query system will only consider plans
+		using the hinted index.
+	*/
+	@embedNullable
+	Nullable!Bson hint;
+
+	/**
+		Map of parameter names and values. Values must be constant or closed
+		expressions that do not reference document fields. Parameters can then
+		be accessed as variables in an aggregate expression context
+		(e.g. `"$$var"`).
+
+		This option is only supported by servers >= 5.0. Older servers >= 2.6 (and possibly earlier) will report an error for using this option.
+	*/
+	@embedNullable
+	Nullable!Bson let;
+
+	/**
+		Specifies the read concern. Only compatible with a write stage. (e.g.
+		`$out`, `$merge`)
+
+		Aggregate commands do not support the $(D ReadConcern.Level.linearizable)
+		level.
+
+		Standards: $(LINK https://github.com/mongodb/specifications/blob/7745234f93039a83ae42589a6c0cdbefcffa32fa/source/read-write-concern/read-write-concern.rst)
+	*/
+	@embedNullable Nullable!ReadConcern readConcern;
+}
+
+/**
+	Standards: $(LINK https://github.com/mongodb/specifications/blob/525dae0aa8791e782ad9dd93e507b60c55a737bb/source/crud/crud.rst#insert-update-replace-delete-and-bulk-writes)
+*/
+struct BulkWriteOptions {
+
+	/**
+		If true, when a write fails, return without performing the remaining
+		writes. If false, when a write fails, continue with the remaining writes,
+		if any.
+
+		Defaults to true.
+	*/
+	bool ordered = true;
+
+	/**
+		If true, allows the write to opt-out of document level validation.
+
+		For servers < 3.2, this option is ignored and not sent as document
+		validation is not available.
+
+		For unacknowledged writes using OP_INSERT, OP_UPDATE, or OP_DELETE, the
+		driver MUST raise an error if the caller explicitly provides a value.
+	*/
+	@embedNullable
+	Nullable!bool bypassDocumentValidation;
+
+	/**
+		A document that expresses the
+		$(LINK2 https://www.mongodb.com/docs/manual/reference/write-concern/,write concern)
+		of the insert command. Omit to use the default write concern.
+	*/
+	@embedNullable
+	Nullable!WriteConcern writeConcern;
+
+	/**
+		Users can specify an arbitrary string to help trace the operation
+		through the database profiler, currentOp, and logs.
+	*/
+	@embedNullable
+	Nullable!string comment;
+}
+
+/**
+	See_Also: $(LINK https://docs.mongodb.com/manual/reference/command/insert/)
+
+	Standards: $(LINK https://github.com/mongodb/specifications/blob/525dae0aa8791e782ad9dd93e507b60c55a737bb/source/crud/crud.rst#insert-update-replace-delete-and-bulk-writes)
+*/
+struct InsertOneOptions {
+	/**
+		If true, allows the write to opt-out of document level validation.
+
+		For servers < 3.2, this option is ignored and not sent as document
+		validation is not available.
+	*/
+	@embedNullable
+	Nullable!bool bypassDocumentValidation;
+
+	/**
+		A document that expresses the
+		$(LINK2 https://www.mongodb.com/docs/manual/reference/write-concern/,write concern)
+		of the insert command. Omit to use the default write concern.
+	*/
+	@embedNullable
+	Nullable!WriteConcern writeConcern;
+
+	/**
+		Users can specify an arbitrary string to help trace the operation
+		through the database profiler, currentOp, and logs.
+	*/
+	@embedNullable
+	Nullable!string comment;
+}
+
+/**
+	See_Also: $(LINK https://docs.mongodb.com/manual/reference/command/insert/)
+
+	Standards: $(LINK https://github.com/mongodb/specifications/blob/525dae0aa8791e782ad9dd93e507b60c55a737bb/source/crud/crud.rst#insert-update-replace-delete-and-bulk-writes)
+*/
+struct InsertManyOptions {
+	/**
+		If true, allows the write to opt-out of document level validation.
+
+		For servers < 3.2, this option is ignored and not sent as document
+		validation is not available.
+	*/
+	@embedNullable
+	Nullable!bool bypassDocumentValidation;
+
+	/**
+		If true, when an insert fails, return without performing the remaining
+		writes. If false, when a write fails, continue with the remaining writes,
+		if any.
+
+		Defaults to true.
+	*/
+	bool ordered = true;
+
+	/**
+		A document that expresses the
+		$(LINK2 https://www.mongodb.com/docs/manual/reference/write-concern/,write concern)
+		of the insert command. Omit to use the default write concern.
+	*/
+	@embedNullable
+	Nullable!WriteConcern writeConcern;
+
+	/**
+		Users can specify an arbitrary string to help trace the operation
+		through the database profiler, currentOp, and logs.
+	*/
+	@embedNullable
+	Nullable!string comment;
+}
+
+/**
+	See_Also: $(LINK https://docs.mongodb.com/manual/reference/command/update/)
+
+	Standards: $(LINK https://github.com/mongodb/specifications/blob/525dae0aa8791e782ad9dd93e507b60c55a737bb/source/crud/crud.rst#insert-update-replace-delete-and-bulk-writes)
+*/
+struct UpdateOptions {
+	/**
+		A set of filters specifying to which array elements an update should
+		apply.
+
+		This option is sent only if the caller explicitly provides a value. The
+		default is to not send a value.
+	*/
+	@embedNullable @errorBefore(WireVersion.v36)
+	Nullable!(Bson[]) arrayFilters;
+
+	/**
+		If true, allows the write to opt-out of document level validation.
+
+		For servers < 3.2, this option is ignored and not sent as document
+		validation is not available.
+	*/
+	@embedNullable
+	Nullable!bool bypassDocumentValidation;
+
+	/**
+		Collation allows users to specify language-specific rules for string
+		comparison, such as rules for letter-case and accent marks.
+	*/
+	@embedNullable @errorBefore(WireVersion.v34)
+	Nullable!Collation collation;
+
+	/**
+		The index to use. Specify either the index name as a string or the index
+		key pattern.
+
+		If specified, then the query system will only consider plans using the
+		hinted index.
+	*/
+	@embedNullable
+	Nullable!Bson hint;
+
+	/**
+		When true, creates a new document if no document matches the query.
+	*/
+	@embedNullable
+	Nullable!bool upsert;
+
+	/**
+		A document that expresses the
+		$(LINK2 https://www.mongodb.com/docs/manual/reference/write-concern/,write concern)
+		of the insert command. Omit to use the default write concern.
+	*/
+	@embedNullable
+	Nullable!WriteConcern writeConcern;
+
+	/**
+		Users can specify an arbitrary string to help trace the operation
+		through the database profiler, currentOp, and logs.
+	*/
+	@embedNullable
+	Nullable!string comment;
+}
+
+/**
+	See_Also: $(LINK https://docs.mongodb.com/manual/reference/command/update/)
+
+	Standards: $(LINK https://github.com/mongodb/specifications/blob/525dae0aa8791e782ad9dd93e507b60c55a737bb/source/crud/crud.rst#insert-update-replace-delete-and-bulk-writes)
+*/
+struct ReplaceOptions {
+	/**
+		If true, allows the write to opt-out of document level validation.
+
+		For servers < 3.2, this option is ignored and not sent as document
+		validation is not available.
+	*/
+	@embedNullable
+	Nullable!bool bypassDocumentValidation;
+
+	/**
+		Collation allows users to specify language-specific rules for string
+		comparison, such as rules for letter-case and accent marks.
+	*/
+	@embedNullable @errorBefore(WireVersion.v34)
+	Nullable!Collation collation;
+
+	/**
+		The index to use. Specify either the index name as a string or the index
+		key pattern.
+
+		If specified, then the query system will only consider plans using the
+		hinted index.
+	*/
+	@embedNullable
+	Nullable!Bson hint;
+
+	/**
+		When true, creates a new document if no document matches the query.
+	*/
+	@embedNullable
+	Nullable!bool upsert;
+
+	/**
+		A document that expresses the
+		$(LINK2 https://www.mongodb.com/docs/manual/reference/write-concern/,write concern)
+		of the insert command. Omit to use the default write concern.
+	*/
+	@embedNullable
+	Nullable!WriteConcern writeConcern;
+
+	/**
+		Users can specify an arbitrary string to help trace the operation
+		through the database profiler, currentOp, and logs.
+	*/
+	@embedNullable
+	Nullable!string comment;
+}
+
+/**
+	See_Also: $(LINK https://docs.mongodb.com/manual/reference/command/delete/)
+
+	Standards: $(LINK https://github.com/mongodb/specifications/blob/525dae0aa8791e782ad9dd93e507b60c55a737bb/source/crud/crud.rst#insert-update-replace-delete-and-bulk-writes)
+*/
+struct DeleteOptions {
+	/**
+		Collation allows users to specify language-specific rules for string
+		comparison, such as rules for letter-case and accent marks.
+	*/
+	@embedNullable @errorBefore(WireVersion.v34)
+	Nullable!Collation collation;
+
+	/**
+		The index to use. Specify either the index name as a string or the index
+		key pattern.
+
+		If specified, then the query system will only consider plans using the
+		hinted index.
+	*/
+	@embedNullable
+	Nullable!Bson hint;
+
+	/**
+		A document that expresses the
+		$(LINK2 https://www.mongodb.com/docs/manual/reference/write-concern/,write concern)
+		of the insert command. Omit to use the default write concern.
+	*/
+	@embedNullable
+	Nullable!WriteConcern writeConcern;
+
+	/**
+		Users can specify an arbitrary string to help trace the operation
+		through the database profiler, currentOp, and logs.
+	*/
+	@embedNullable
+	Nullable!string comment;
+}
+
+struct BulkWriteResult {
+	/**
+		Number of documents inserted.
+	*/
+	long insertedCount;
+
+	/**
+		The identifiers that were automatically generated, if not set.
+	*/
+	BsonObjectID[size_t] insertedIds;
+
+	/**
+		Number of documents matched for update.
+	*/
+	long matchedCount;
+
+	/**
+		Number of documents modified.
+	*/
+	long modifiedCount;
+
+	/**
+		Number of documents deleted.
+	*/
+	long deletedCount;
+
+	/**
+		Number of documents upserted.
+	*/
+	long upsertedCount;
+
+	/**
+		Map of the index of the operation to the id of the upserted document.
+	*/
+	BsonObjectID[size_t] upsertedIds;
+}
+
+struct InsertOneResult {
+	/**
+		The identifier that was automatically generated, if not set.
+	*/
+	BsonObjectID insertedId;
+}
+
+struct InsertManyResult {
+	/**
+		The identifiers that were automatically generated, if not set.
+	*/
+	BsonObjectID[size_t] insertedIds;
+}
+
+struct DeleteResult {
+	/**
+		The number of documents that were deleted.
+	*/
+	long deletedCount;
+}
+
+struct UpdateResult {
+	/**
+		The number of documents that matched the filter.
+	*/
+	long matchedCount;
+
+	/**
+		The number of documents that were modified.
+	*/
+	long modifiedCount;
+
+	/**
+		The number of documents that were upserted.
+	*
+		NOT REQUIRED: Drivers may choose to not provide this property so long as
+		it is always possible to infer whether an upsert has taken place. Since
+		the "_id" of an upserted document could be null, a null "upsertedId" may
+		be ambiguous in some drivers. If so, this field can be used to indicate
+		whether an upsert has taken place.
+	*/
+	long upsertedCount;
+
+	/**
+		The identifier of the inserted document if an upsert took place.
+	*/
+	Bson upsertedId;
+}

--- a/mongodb/vibe/db/mongo/impl/crud.d
+++ b/mongodb/vibe/db/mongo/impl/crud.d
@@ -233,6 +233,16 @@ struct FindOptions
 	Nullable!Bson sort;
 
 	/**
+		If true, when an insert fails, return without performing the remaining
+		writes. If false, when a write fails, continue with the remaining writes,
+		if any.
+
+		Defaults to true.
+	*/
+	@embedNullable
+	Nullable!bool ordered;
+
+	/**
 		Specifies the read concern. Only compatible with a write stage. (e.g.
 		`$out`, `$merge`)
 
@@ -530,7 +540,8 @@ struct BulkWriteOptions {
 
 		Defaults to true.
 	*/
-	bool ordered = true;
+	@embedNullable
+	Nullable!bool ordered;
 
 	/**
 		If true, allows the write to opt-out of document level validation.
@@ -613,7 +624,8 @@ struct InsertManyOptions {
 
 		Defaults to true.
 	*/
-	bool ordered = true;
+	@embedNullable
+	Nullable!bool ordered;
 
 	/**
 		A document that expresses the
@@ -640,9 +652,6 @@ struct UpdateOptions {
 	/**
 		A set of filters specifying to which array elements an update should
 		apply.
-
-		This option is sent only if the caller explicitly provides a value. The
-		default is to not send a value.
 	*/
 	@embedNullable @errorBefore(WireVersion.v36)
 	Nullable!(Bson[]) arrayFilters;
@@ -653,7 +662,7 @@ struct UpdateOptions {
 		For servers < 3.2, this option is ignored and not sent as document
 		validation is not available.
 	*/
-	@embedNullable
+	@embedNullable @since(WireVersion.v32)
 	Nullable!bool bypassDocumentValidation;
 
 	/**
@@ -786,6 +795,17 @@ struct DeleteOptions {
 	*/
 	@embedNullable
 	Nullable!string comment;
+
+	/**
+		Map of parameter names and values. Values must be constant or closed
+		expressions that do not reference document fields. Parameters can then
+		be accessed as variables in an aggregate expression context
+		(e.g. `"$$var"`).
+
+		This option is only supported by servers >= 5.0. Older servers >= 2.6 (and possibly earlier) will report an error for using this option.
+	*/
+	@embedNullable
+	Nullable!Bson let;
 }
 
 struct BulkWriteResult {
@@ -858,18 +878,9 @@ struct UpdateResult {
 	long modifiedCount;
 
 	/**
-		The number of documents that were upserted.
-	*
-		NOT REQUIRED: Drivers may choose to not provide this property so long as
-		it is always possible to infer whether an upsert has taken place. Since
-		the "_id" of an upserted document could be null, a null "upsertedId" may
-		be ambiguous in some drivers. If so, this field can be used to indicate
-		whether an upsert has taken place.
+		The identifier of the inserted document if an upsert took place. Can be
+		none if no upserts took place, can be multiple if using the updateImpl
+		helper.
 	*/
-	long upsertedCount;
-
-	/**
-		The identifier of the inserted document if an upsert took place.
-	*/
-	Bson upsertedId;
+	BsonObjectID[] upsertedIds;
 }

--- a/mongodb/vibe/db/mongo/impl/crud.d
+++ b/mongodb/vibe/db/mongo/impl/crud.d
@@ -1,3 +1,10 @@
+/**
+	MongoDB CRUD API definitions.
+
+	Copyright: © 2022 Jan Jurzitza
+	License: Subject to the terms of the MIT license, as written in the included LICENSE.txt file.
+	Authors: Jan Jurzitza
+*/
 module vibe.db.mongo.impl.crud;
 
 import core.time;
@@ -9,6 +16,7 @@ import std.typecons;
 
 @safe:
 
+deprecated("Use UpdateOptions instead")
 enum UpdateFlags {
 	none         = 0,    /// Normal update of a single document.
 	upsert       = 1<<0, /// Creates a document if none exists.
@@ -19,6 +27,7 @@ enum UpdateFlags {
 	MultiUpdate = multiUpdate /// Deprecated compatibility alias
 }
 
+deprecated("Use InsertOneOptions or InsertManyOptions instead")
 enum InsertFlags {
 	none             = 0,    /// Normal insert.
 	continueOnError  = 1<<0, /// For multiple inserted documents, continues inserting further documents after a failure.
@@ -48,6 +57,7 @@ enum QueryFlags {
 	Partial = partial /// Deprecated compatibility alias
 }
 
+deprecated("Use DeleteOptions instead")
 enum DeleteFlags {
 	none          = 0,
 	singleRemove  = 1<<0,

--- a/mongodb/vibe/db/mongo/impl/index.d
+++ b/mongodb/vibe/db/mongo/impl/index.d
@@ -1,3 +1,10 @@
+/**
+	MongoDB index API definitions.
+
+	Copyright: © 2020-2022 Jan Jurzitza
+	License: Subject to the terms of the MIT license, as written in the included LICENSE.txt file.
+	Authors: Jan Jurzitza
+*/
 module vibe.db.mongo.impl.index;
 
 @safe:

--- a/mongodb/vibe/db/mongo/sessionstore.d
+++ b/mongodb/vibe/db/mongo/sessionstore.d
@@ -85,7 +85,7 @@ final class MongoSessionStore : SessionStore {
 	Session create()
 	{
 		auto s = createSessionInstance();
-		m_sessions.insert(SessionEntry(s.id, Clock.currTime(UTC())));
+		m_sessions.insertOne(SessionEntry(s.id, Clock.currTime(UTC())));
 		return s;
 	}
 
@@ -104,7 +104,9 @@ final class MongoSessionStore : SessionStore {
 	Variant get(string id, string name, lazy Variant defaultVal)
 	@trusted {
 		auto f = name.escape;
-		auto r = m_sessions.findOne(["_id": id], [f: 1]);
+		FindOptions options;
+		options.projection = Bson([f: Bson(1)]);
+		auto r = m_sessions.findOne(["_id": id], options);
 		if (r.isNull) return defaultVal;
 		auto v = r.tryIndex(f);
 		if (v.isNull) return defaultVal;
@@ -114,7 +116,9 @@ final class MongoSessionStore : SessionStore {
 	bool isKeySet(string id, string key)
 	{
 		auto f = key.escape;
-		auto r = m_sessions.findOne(["_id": id], [f: 1]);
+		FindOptions options;
+		options.projection = Bson([f: Bson(1)]);
+		auto r = m_sessions.findOne(["_id": id], options);
 		if (r.isNull) return false;
 		return !r.tryIndex(f).isNull;
 	}

--- a/mongodb/vibe/db/mongo/settings.d
+++ b/mongodb/vibe/db/mongo/settings.d
@@ -148,6 +148,17 @@ bool parseMongoDBUrl(out MongoClientSettings cfg, string url)
 				}
 			}
 
+			bool setMsecs(ref Duration dst)
+			{
+				try {
+					dst = to!long(value).msecs;
+					return true;
+				} catch( Exception e ){
+					logError("Value for '%s' must be an integer but was '%s'.", option, value);
+					return false;
+				}
+			}
+
 			void warnNotImplemented()
 			{
 				logDiagnostic("MongoDB option %s not yet implemented.", option);
@@ -162,8 +173,8 @@ bool parseMongoDBUrl(out MongoClientSettings cfg, string url)
 				case "safe": setBool(cfg.safe); break;
 				case "fsync": setBool(cfg.fsync); break;
 				case "journal": setBool(cfg.journal); break;
-				case "connecttimeoutms": setLong(cfg.connectTimeoutMS); break;
-				case "sockettimeoutms": setLong(cfg.socketTimeoutMS); break;
+				case "connecttimeoutms": setMsecs(cfg.connectTimeout); break;
+				case "sockettimeoutms": setMsecs(cfg.socketTimeout); break;
 				case "tls": setBool(cfg.ssl); break;
 				case "ssl": setBool(cfg.ssl); break;
 				case "sslverifycertificate": setBool(cfg.sslverifycertificate); break;

--- a/mongodb/vibe/db/mongo/settings.d
+++ b/mongodb/vibe/db/mongo/settings.d
@@ -576,8 +576,8 @@ class MongoClientSettings
 	 * Resolves the database to run authentication commands on.
 	 * (authSource if set, otherwise the URI's database if set, otherwise "admin")
 	 */
-	string getAuthDatabase() @safe @nogc nothrow pure
-	{
+	string getAuthDatabase()
+	@safe @nogc nothrow pure const return {
 		if (authSource.length)
 			return authSource;
 		else if (database.length)

--- a/mongodb/vibe/db/mongo/settings.d
+++ b/mongodb/vibe/db/mongo/settings.d
@@ -9,7 +9,7 @@ module vibe.db.mongo.settings;
 
 import vibe.core.log;
 import vibe.data.bson;
-import vibe.db.mongo.flags : QueryFlags;
+deprecated import vibe.db.mongo.flags : QueryFlags;
 import vibe.inet.webform;
 
 import std.conv : to;
@@ -157,7 +157,6 @@ bool parseMongoDBUrl(out MongoClientSettings cfg, string url)
 
 				default: logWarn("Unknown MongoDB option %s", option); break;
 				case "appname": cfg.appName = value; break;
-				case "slaveok": bool v; if( setBool(v) && v ) cfg.defQueryFlags |= QueryFlags.SlaveOk; break;
 				case "replicaset": cfg.replicaSet = value; warnNotImplemented(); break;
 				case "safe": setBool(cfg.safe); break;
 				case "fsync": setBool(cfg.fsync); break;
@@ -208,7 +207,6 @@ unittest
 	assert(cfg.database == "");
 	assert(cfg.hosts[0].name == "localhost");
 	assert(cfg.hosts[0].port == 27017);
-	assert(cfg.defQueryFlags == QueryFlags.None);
 	assert(cfg.replicaSet == "");
 	assert(cfg.safe == false);
 	assert(cfg.w == Bson.init);
@@ -241,7 +239,7 @@ unittest
 	assert(cfg.hosts[0].port == 27017);
 
 	cfg = MongoClientSettings.init;
-	assert(parseMongoDBUrl(cfg, "mongodb://host1,host2,host3/?safe=true&w=2&wtimeoutMS=2000&slaveOk=true&ssl=true&sslverifycertificate=false"));
+	assert(parseMongoDBUrl(cfg, "mongodb://host1,host2,host3/?safe=true&w=2&wtimeoutMS=2000&ssl=true&sslverifycertificate=false"));
 	assert(cfg.username == "");
 	//assert(cfg.password == "");
 	assert(cfg.digest == "");
@@ -256,7 +254,6 @@ unittest
 	assert(cfg.safe == true);
 	assert(cfg.w == Bson(2L));
 	assert(cfg.wTimeoutMS == 2000);
-	assert(cfg.defQueryFlags == QueryFlags.SlaveOk);
 	assert(cfg.ssl == true);
 	assert(cfg.sslverifycertificate == false);
 
@@ -402,12 +399,7 @@ class MongoClientSettings
 	 */
 	string database;
 
-	/**
-	 * Flags to use on all database query commands. The
-	 * $(REF slaveOk, vibe,db,mongo,flags,QueryFlags) bit may be set using the
-	 * "slaveok" query parameter inside the MongoDB URL.
-	 */
-	QueryFlags defQueryFlags = QueryFlags.None;
+	deprecated("unused since at least before v3.6") QueryFlags defQueryFlags = QueryFlags.None;
 
 	/**
 	 * Specifies the name of the replica set, if the mongod is a member of a

--- a/mongodb/vibe/db/mongo/settings.d
+++ b/mongodb/vibe/db/mongo/settings.d
@@ -160,8 +160,8 @@ bool parseMongoDBUrl(out MongoClientSettings cfg, string url)
 				case "safe": setBool(cfg.safe); break;
 				case "fsync": setBool(cfg.fsync); break;
 				case "journal": setBool(cfg.journal); break;
-				case "connecttimeoutms": setLong(cfg.connectTimeoutMS); warnNotImplemented(); break;
-				case "sockettimeoutms": setLong(cfg.socketTimeoutMS); warnNotImplemented(); break;
+				case "connecttimeoutms": setLong(cfg.connectTimeoutMS); break;
+				case "sockettimeoutms": setLong(cfg.socketTimeoutMS); break;
 				case "tls": setBool(cfg.ssl); break;
 				case "ssl": setBool(cfg.ssl); break;
 				case "sslverifycertificate": setBool(cfg.sslverifycertificate); break;
@@ -454,16 +454,14 @@ class MongoClientSettings
 
 	/**
 	 * The time in milliseconds to attempt a connection before timing out.
-	 *
-	 * Bugs: Not yet implemented
 	 */
-	long connectTimeoutMS;
+	long connectTimeoutMS = 10_000;
 
 	/**
 	 * The time in milliseconds to attempt a send or receive on a socket before
 	 * the attempt times out.
 	 *
-	 * Bugs: Not yet implemented
+	 * Bugs: Not implemented for sending
 	 */
 	long socketTimeoutMS;
 

--- a/mongodb/vibe/db/mongo/settings.d
+++ b/mongodb/vibe/db/mongo/settings.d
@@ -215,7 +215,7 @@ unittest
 	assert(cfg.wTimeoutMS == long.init);
 	assert(cfg.fsync == false);
 	assert(cfg.journal == false);
-	assert(cfg.connectTimeoutMS == long.init);
+	assert(cfg.connectTimeoutMS == 10_000);
 	assert(cfg.socketTimeoutMS == long.init);
 	assert(cfg.ssl == bool.init);
 	assert(cfg.sslverifycertificate == true);

--- a/mongodb/vibe/db/mongo/settings.d
+++ b/mongodb/vibe/db/mongo/settings.d
@@ -12,6 +12,7 @@ import vibe.data.bson;
 deprecated import vibe.db.mongo.flags : QueryFlags;
 import vibe.inet.webform;
 
+import core.time;
 import std.conv : to;
 import std.digest : toHexString;
 import std.digest.md : md5Of;
@@ -449,17 +450,41 @@ class MongoClientSettings
 	bool journal;
 
 	/**
-	 * The time in milliseconds to attempt a connection before timing out.
+	 * The time to attempt a connection before timing out.
 	 */
-	long connectTimeoutMS = 10_000;
+	Duration connectTimeout = 10.seconds;
+
+	/// ditto
+	long connectTimeoutMS() const @property
+	@safe {
+		return connectTimeout.total!"msecs";
+	}
+
+	/// ditto
+	void connectTimeoutMS(long ms) @property
+	@safe {
+		connectTimeout = ms.msecs;
+	}
 
 	/**
-	 * The time in milliseconds to attempt a send or receive on a socket before
-	 * the attempt times out.
+	 * The time to attempt a send or receive on a socket before the attempt
+	 * times out.
 	 *
 	 * Bugs: Not implemented for sending
 	 */
-	long socketTimeoutMS;
+	Duration socketTimeout = Duration.zero;
+
+	/// ditto
+	long socketTimeoutMS() const @property
+	@safe {
+		return socketTimeout.total!"msecs";
+	}
+
+	/// ditto
+	void socketTimeoutMS(long ms) @property
+	@safe {
+		socketTimeout = ms.msecs;
+	}
 
 	/**
 	 * Enables or disables TLS/SSL for the connection.

--- a/tests/mongodb/_connection/dub.json
+++ b/tests/mongodb/_connection/dub.json
@@ -3,5 +3,6 @@
 	"description": "MongoDB connection tests",
 	"dependencies": {
 		"vibe-d:mongodb": {"path": "../../../"}
-	}
+	},
+	"debugVersions": ["VibeVerboseMongo"]
 }

--- a/tests/mongodb/_connection/source/app.d
+++ b/tests/mongodb/_connection/source/app.d
@@ -143,6 +143,10 @@ int main(string[] args)
 	foreach (v; coll.find())
 		logInfo("\t%s", v);
 
+	logInfo("Filtering for target:", objID);
+	foreach (v; coll.find(["_id": objID]))
+		logInfo("\t%s", v);
+
 	auto v = coll.findOne(["_id": objID]);
 	assert(!v.isNull, "Just-inserted entry is not added to the database");
 	assert(v["hello"].get!string == "world",

--- a/tests/mongodb/_connection/source/app.d
+++ b/tests/mongodb/_connection/source/app.d
@@ -20,10 +20,12 @@ int main(string[] args)
 		return 1;
 	}
 
-	runTask({ sleep(10.seconds); assert(false, "Timeout exceeded"); });
+	runTask({ sleep(20.seconds); assert(false, "Timeout exceeded"); });
 
 	port = args[1].to!ushort;
 	MongoClientSettings settings = new MongoClientSettings;
+	settings.connectTimeoutMS = 5_000;
+	settings.socketTimeoutMS = 2_000;
 
 	int authStep = 0;
 	foreach (arg; args[2 .. $])

--- a/tests/mongodb/_connection/source/app.d
+++ b/tests/mongodb/_connection/source/app.d
@@ -140,12 +140,12 @@ int main(string[] args)
 	}
 
 	logInfo("Everything in DB (target=%s):", objID);
-	foreach (v; coll.find())
+	size_t indexCheck;
+	foreach (v; coll.find().byPair)
+	{
+		assert(v[0] == indexCheck++);
 		logInfo("\t%s", v);
-
-	logInfo("Filtering for target:", objID);
-	foreach (v; coll.find(["_id": objID]))
-		logInfo("\t%s", v);
+	}
 
 	auto v = coll.findOne(["_id": objID]);
 	assert(!v.isNull, "Just-inserted entry is not added to the database");

--- a/tests/mongodb/_connection/source/app.d
+++ b/tests/mongodb/_connection/source/app.d
@@ -13,6 +13,8 @@ int main(string[] args)
 	string username, password;
 	ushort port;
 
+	setLogLevel(LogLevel.diagnostic);
+
 	if (args.length < 2)
 	{
 		logError("Usage: %s [port] (failconnect) (faildb) (failauth) (auth [username] [password])",
@@ -107,7 +109,7 @@ int main(string[] args)
 	try
 	{
 		logInfo(`Trying to insert {"_id": "%s", "hello": "world"}`, objID);
-		coll.insert(Bson(["_id": Bson(objID), "hello": Bson("world")]));
+		coll.insertOne(Bson(["_id": Bson(objID), "hello": Bson("world")]));
 	}
 	catch (MongoDriverException e)
 	{


### PR DESCRIPTION
So there was a bunch of legacy code from ancient MongoDB driver versions still around, which made this a bit difficult. I mostly kept old compatibility in, however since this release we are only going to officially support MongoDB 3.6 and up. (which has long been EOLd anyway) In theory a bunch of stuff still works with even older servers though, but I would not give any guarantees there. Methods that I could not upgrade transparently I simply deprecated with a note that they will stop working on MongoDB 5.1 and up, due to them dropping support for all packets except OP_MSG, which is now used everywhere.

The basic find method without and with query was upgraded transparently, however you can no longer use $query and query fields inside your query to overwrite the whole query. (was never documented anyway and I'm sure that's more of a security vulnerability than a feature)

The other stuff is still mostly there, but we now implement the proper CRUD API that the MongoDB driver spec mandates, making us consistent with all other drivers as well as supporting all the MongoDB server versions since 3.6.

I have updated the CI, it no longer runs the MongoDB tests on the general CI actions on all OSes, however now it instead it only runs the MongoDB tests on Ubuntu-20.04, but with all the stable versions from 3.6 up to 6.0.

Still needs some more testing and CI fixes, but the basic OP_MSG implementation and adoption of cursors, handshake, authentication, CRUD methods and runCommand is there.

Maybe the PR looks a little large at first, but these components are really quite interconnected. It would be possible to split it in a few places though, if desired.

This PR contains full CRUD API implementation because since we cannot use OP_QUERY anymore, we need to use query commands, which are defined in the driver spec as this CRUD API.

What I very much like about the unification of the runCommand, query and OP_MSG things into a single runCommand function now: a lot of code duplication of error checking has been removed and unified into the single function, which makes the code a lot more resilient imo. User-custom methods still run without error checking by default in the deprecated overload, but it recommends them to use the overload that explicitly takes in a boolean if we want error checking or not.

A few of the MongoDB index APIs have been creating custom cursors before, manually parsing the cursor response object. This has now all been moved into the MongoCursor class and it now only has a single implementation, no longer a Find and a Generic implementation, which I think makes it also easier to read.