### PR TITLE
reimplement MongoCollection.find with projection

### DIFF
--- a/data/vibe/data/serialization.d
+++ b/data/vibe/data/serialization.d
@@ -1892,7 +1892,7 @@ unittest // Testing corner case: member function returning by ref
 	static struct S
 	{
 		int i;
-		ref int foo() { return i; }
+		ref int foo() return { return i; }
 	}
 
 	static assert(__traits(compiles, { S().serializeToJson(); }));

--- a/examples/bench-mongodb/source/app.d
+++ b/examples/bench-mongodb/source/app.d
@@ -24,7 +24,7 @@ void main()
 		//string s;
 	}
 
-	auto db = connectMongoDB("localhost").getDatabase("test");
+	auto db = connectMongoDB("127.0.0.1").getDatabase("test");
 	auto coll = db["benchmark"];
 	coll.remove();
 	foreach (i; 0 .. 10) {
@@ -33,7 +33,7 @@ void main()
 		itm.i = i;
 		itm.d = i * 1.3;
 		//itm.s = "Hello, World!";
-		coll.insert(itm);
+		coll.insertOne(itm);
 	}
 
 	logInfo("Running queries...");

--- a/examples/mongodb/source/app.d
+++ b/examples/mongodb/source/app.d
@@ -6,7 +6,7 @@ import std.array;
 void main()
 {
 	logInfo("Connecting to DB...");
-	auto db = connectMongoDB("localhost").getDatabase("test");
+	auto db = connectMongoDB("127.0.0.1").getDatabase("test");
 	auto coll = db["test"];
 
 	logInfo("Querying DB...");

--- a/mongodb/vibe/db/mongo/collection.d
+++ b/mongodb/vibe/db/mongo/collection.d
@@ -248,7 +248,7 @@ struct MongoCollection {
 		}
 		cmd["deletes"] = Bson(deletesBson);
 
-		auto n = database.runCommandChecked(cmd)["n"].get!long;
+		auto n = database.runCommandChecked(cmd)["n"].to!long;
 		return DeleteResult(n);
 	}
 
@@ -374,8 +374,8 @@ struct MongoCollection {
 
 		auto res = database.runCommandChecked(cmd);
 		auto ret = UpdateResult(
-			res["n"].get!long,
-			res["nModified"].get!long,
+			res["n"].to!long,
+			res["nModified"].to!long,
 		);
 		auto upserted = res["upserted"].opt!(Bson[]);
 		if (upserted.length)
@@ -668,7 +668,7 @@ struct MongoCollection {
 				__traits(getMember, aggOptions, name) = field;
 		}
 		auto reply = aggregate(pipeline, aggOptions).front;
-		return reply["n"].get!long;
+		return reply["n"].to!long;
 	}
 
 	/**
@@ -693,7 +693,7 @@ struct MongoCollection {
 			AggregateOptions aggOptions;
 			aggOptions.maxTimeMS = options.maxTimeMS;
 			auto reply = aggregate(pipeline, aggOptions).front;
-			return reply["n"].get!long;
+			return reply["n"].to!long;
 		} else {
 			return countImpl(null);
 		}

--- a/mongodb/vibe/db/mongo/connection.d
+++ b/mongodb/vibe/db/mongo/connection.d
@@ -700,7 +700,8 @@ final class MongoConnection {
 		static MongoDBInfo toInfo(const(Bson) db_doc) {
 			return MongoDBInfo(
 				db_doc["name"].get!string,
-				db_doc["sizeOnDisk"].get!double,
+				// double on MongoDB < 5.0, long afterwards
+				db_doc["sizeOnDisk"].to!double,
 				db_doc["empty"].get!bool
 			);
 		}

--- a/mongodb/vibe/db/mongo/connection.d
+++ b/mongodb/vibe/db/mongo/connection.d
@@ -676,7 +676,7 @@ final class MongoConnection {
 				error["errmsg"].opt!string(error["err"].opt!string("")),
 				error["code"].opt!int(-1),
 				error["connectionId"].opt!int(-1),
-				error["n"].get!int(),
+				error["n"].opt!int(-1),
 				error["ok"].get!double()
 			);
 		} catch (Exception e) {

--- a/mongodb/vibe/db/mongo/database.d
+++ b/mongodb/vibe/db/mongo/database.d
@@ -98,6 +98,8 @@ struct MongoDatabase
 
 	/** Performs a filesystem/disk sync of the database on the server.
 
+		This method can only be called on the admin database.
+
 		See $(LINK http://www.mongodb.org/display/DOCS/fsync+Command)
 
 		Returns: check documentation

--- a/mongodb/vibe/db/mongo/sessionstore.d
+++ b/mongodb/vibe/db/mongo/sessionstore.d
@@ -98,7 +98,7 @@ final class MongoSessionStore : SessionStore {
 
 	void set(string id, string name, Variant value)
 	@trusted {
-		m_sessions.update(["_id": id], ["$set": [name.escape: value.get!Bson, "time": Clock.currTime(UTC()).serializeToBson]]);
+		m_sessions.updateOne(["_id": id], ["$set": [name.escape: value.get!Bson, "time": Clock.currTime(UTC()).serializeToBson]]);
 	}
 
 	Variant get(string id, string name, lazy Variant defaultVal)
@@ -125,12 +125,12 @@ final class MongoSessionStore : SessionStore {
 
 	void remove(string id, string key)
 	{
-		m_sessions.update(["_id": id], ["$unset": [key.escape: 1]]);
+		m_sessions.updateOne(["_id": id], ["$unset": [key.escape: 1]]);
 	}
 
 	void destroy(string id)
 	{
-		m_sessions.remove(["_id": id]);
+		m_sessions.deleteOne(["_id": id]);
 	}
 
 	int iterateSession(string id, scope int delegate(string key) @safe del)

--- a/tests/mongodb/index/source/app.d
+++ b/tests/mongodb/index/source/app.d
@@ -25,10 +25,10 @@ void runTest(ushort port)
 	assert(coll.database.getLastError().code < 0);
 	assert(coll.name == "indextest.collection");
 	assert(coll.database.name == "test");
-	coll.remove();
-	coll.insert(Bson.fromJson(parseJsonString(`{ "_id": 1, "key": "hello", "idioma": "portuguese", "quote": "A sorte protege os audazes" }`)));
-	coll.insert(Bson.fromJson(parseJsonString(`{ "_id": 2, "key": "foo", "idioma": "spanish", "quote": "Nada hay más surrealista que la realidad." }`)));
-	coll.insert(Bson.fromJson(parseJsonString(`{ "_id": 3, "key": "bar", "idioma": "english", "quote": "is this a dagger which I see before me" }`)));
+	coll.deleteAll();
+	coll.insertOne(Bson.fromJson(parseJsonString(`{ "_id": 1, "key": "hello", "idioma": "portuguese", "quote": "A sorte protege os audazes" }`)));
+	coll.insertOne(Bson.fromJson(parseJsonString(`{ "_id": 2, "key": "foo", "idioma": "spanish", "quote": "Nada hay más surrealista que la realidad." }`)));
+	coll.insertOne(Bson.fromJson(parseJsonString(`{ "_id": 3, "key": "bar", "idioma": "english", "quote": "is this a dagger which I see before me" }`)));
 
 	struct CustomIndex
 	{
@@ -160,9 +160,10 @@ int main(string[] args)
 {
 	int ret = 0;
 	ushort port = args.length > 1 ? args[1].to!ushort : MongoClientSettings.defaultPort;
-	runTask({
-		scope (exit) exitEventLoop(true);
-		runTest(port);
+	runTask(() nothrow {
+		try runTest(port);
+		catch (Exception e) assert(false, e.toString());
+		finally exitEventLoop(true);
 	});
 	runEventLoop();
 	return ret;

--- a/tests/mongodb/index/source/app.d
+++ b/tests/mongodb/index/source/app.d
@@ -22,9 +22,6 @@ void runTest(ushort port)
 	MongoClient client = connectMongoDB("127.0.0.1", port);
 
 	MongoCollection coll = client.getCollection("test.indextest.collection");
-	assert(coll.database.getLastError().code < 0);
-	assert(coll.name == "indextest.collection");
-	assert(coll.database.name == "test");
 	coll.deleteAll();
 	coll.insertOne(Bson.fromJson(parseJsonString(`{ "_id": 1, "key": "hello", "idioma": "portuguese", "quote": "A sorte protege os audazes" }`)));
 	coll.insertOne(Bson.fromJson(parseJsonString(`{ "_id": 2, "key": "foo", "idioma": "spanish", "quote": "Nada hay más surrealista que la realidad." }`)));

--- a/tests/mongodb/insert-remove-aggregate/source/app.d
+++ b/tests/mongodb/insert-remove-aggregate/source/app.d
@@ -8,7 +8,7 @@ import vibe.core.log;
 import vibe.data.bson;
 import vibe.db.mongo.mongo;
 
-import std.algorithm : canFind, equal, map, sort;
+import std.algorithm : all, canFind, equal, map, sort;
 import std.conv : to;
 import std.encoding : sanitize;
 
@@ -25,11 +25,11 @@ void runTest(ushort port)
 	assert(coll.database.getLastError().code < 0);
 	assert(coll.name == "collection");
 	assert(coll.database.name == "test");
-	coll.remove();
-	coll.insert([ "key1" : "value1", "key2" : "value2"]);
-	coll.update(["key1" : "value1"], [ "key1" : "value1", "key2" : "1337"]);
-	assert(coll.database.getLastError().n == 1);
-	auto data = coll.findOne(["key1" : "value1"]);
+	coll.deleteAll();
+	coll.insertOne(["key1": "value1", "key2": "value2"]);
+	auto replaceResult = coll.replaceOne(["key1": "value1"], ["key1": "value1", "key2": "1337"]);
+	assert(replaceResult.modifiedCount == 1);
+	auto data = coll.findOne(["key1": "value1"]);
 	assert(!data.isNull());
 	assert(data["key2"].get!string() == "1337");
 	coll.database.fsync();
@@ -37,27 +37,40 @@ void runTest(ushort port)
 	assert(!logBson.isNull());
 
 	// testing cursor range interface
-	coll.remove();
-	coll.insert(["key1" : "value1", "key2": "3"]);
-	coll.insert(["key1" : "value2", "key2": "2"]);
-	coll.insert(["key1" : "value2", "key2": "1"]);
-	auto data1 = coll.find(["key1" : "value1"]);
-	auto data2 = coll.find(["key1" : "value2"]);
+	coll.deleteAll();
+	coll.insertOne(["key1": "value1", "key2": "3"]);
+	coll.insertOne(["key1": "value2", "key2": "2"]);
+	coll.insertOne(["key1": "value2", "key2": "1"]);
+	auto data1 = coll.find(["key1": "value1"]);
+	auto data2 = coll.find(["key1": "value2"]);
 
 	import std.range;
-	auto converted = zip(data1, data2).map!( a => a[0]["key1"].get!string() ~ a[1]["key1"].get!string() )();
+
+	auto converted = zip(data1, data2).map!(
+		a => a[0]["key1"].get!string() ~ a[1]["key1"].get!string())();
 	assert(!converted.empty);
 	assert(converted.front == "value1value2");
+
+	auto projectedData = coll
+		.find(Bson.emptyObject, ["key2": 1])
+		.sort(["key2": 1])
+		.array;
+	assert(projectedData[0]["key2"].get!string == "1");
+	assert(projectedData[1]["key2"].get!string == "2");
+	assert(projectedData[2]["key2"].get!string == "3");
+
+	assert(projectedData.all!(d =>
+		d.get!(Bson[string]).byKey.array.sort!"a<b".array
+			== ["_id", "key2"]));
 
 	auto names = client.getDatabases().map!(dbs => dbs.name).array;
 	assert(names.canFind("test"));
 	assert(names.canFind("local"));
 
-	import std.stdio;
 	AggregateOptions options;
 	options.cursor.batchSize = 5;
 	assert(coll.aggregate!DBTestEntry(
-		[
+			[
 			["$match": Bson(["key1": Bson("value2")])],
 			["$sort": Bson(["key2": Bson(-1)])]
 		],
@@ -65,7 +78,7 @@ void runTest(ushort port)
 	).equal([DBTestEntry("value2", "2"), DBTestEntry("value2", "1")]));
 
 	assert(coll.aggregate!DBTestEntry(
-		[
+			[
 			["$match": Bson(["key1": Bson("value2")])],
 			["$sort": Bson(["key2": Bson(1)])]
 		],
@@ -73,17 +86,19 @@ void runTest(ushort port)
 	).equal([DBTestEntry("value2", "1"), DBTestEntry("value2", "2")]));
 
 	assert(coll.aggregate(
-		["$match": Bson(["key1": Bson("value2")])],
-		["$sort": Bson(["key2": Bson(1)])]
-	).get!(Bson[]).map!(a => a["key2"].get!string).equal(["1", "2"]));
+			["$match": Bson(["key1": Bson("value2")])],
+			["$sort": Bson(["key2": Bson(1)])]
+		).get!(Bson[])
+			.map!(a => a["key2"].get!string)
+			.equal(["1", "2"]));
 
 	// test distinct()
 	coll.drop();
-	coll.insert(["a": "first", "b": "foo"]);
-	coll.insert(["a": "first", "b": "bar"]);
-	coll.insert(["a": "first", "b": "bar"]);
-	coll.insert(["a": "second", "b": "baz"]);
-	coll.insert(["a": "second", "b": "bam"]);
+	coll.insertOne(["a": "first", "b": "foo"]);
+	coll.insertOne(["a": "first", "b": "bar"]);
+	coll.insertOne(["a": "first", "b": "bar"]);
+	coll.insertOne(["a": "second", "b": "baz"]);
+	coll.insertOne(["a": "second", "b": "bam"]);
 	auto d = coll.distinct!string("b", ["a": "first"]).array;
 	d.sort!"a<b";
 	assert(d == ["bar", "foo"]);
@@ -92,9 +107,12 @@ void runTest(ushort port)
 int main(string[] args)
 {
 	int ret = 0;
-	ushort port = args.length > 1 ? args[1].to!ushort : MongoClientSettings.defaultPort;
-	runTask({
+	ushort port = args.length > 1
+		? args[1].to!ushort
+		: MongoClientSettings.defaultPort;
+	runTask(() nothrow {
 		try runTest(port);
+		catch (Exception e) assert(false, e.toString());
 		finally exitEventLoop(true);
 	});
 	runEventLoop();

--- a/tests/mongodb/insert-remove-aggregate/source/app.d
+++ b/tests/mongodb/insert-remove-aggregate/source/app.d
@@ -29,7 +29,7 @@ void runTest(ushort port)
 	auto data = coll.findOne(["key1": "value1"]);
 	assert(!data.isNull());
 	assert(data["key2"].get!string() == "1337");
-	coll.database.fsync();
+	client.getDatabase("admin").fsync();
 	auto logBson = client.getDatabase("admin").getLog("global");
 	assert(!logBson.isNull());
 

--- a/tests/mongodb/insert-remove-aggregate/source/app.d
+++ b/tests/mongodb/insert-remove-aggregate/source/app.d
@@ -22,9 +22,6 @@ void runTest(ushort port)
 	MongoClient client = connectMongoDB("127.0.0.1", port);
 
 	auto coll = client.getCollection("test.collection");
-	assert(coll.database.getLastError().code < 0);
-	assert(coll.name == "collection");
-	assert(coll.database.name == "test");
 	coll.deleteAll();
 	coll.insertOne(["key1": "value1", "key2": "value2"]);
 	auto replaceResult = coll.replaceOne(["key1": "value1"], ["key1": "value1", "key2": "1337"]);


### PR DESCRIPTION
Also tests it + fixed examples + fixed deprecations

Restores backwards compatibility with older code using returnFieldMapping. I noticed the old remove/update functions are always gonna still use the old behavior. We could in theory add compatibility layers there to let users just use the old API, but I would prefer users to upgrade to the better standardized API that's common across all drivers.