### PR TITLE
Change an instance of 'in' to 'scope const'

### DIFF
--- a/stream/vibe/stream/wrapper.d
+++ b/stream/vibe/stream/wrapper.d
@@ -352,7 +352,7 @@ struct StreamOutputRange(OutputStream, size_t buffer_size = 256)
 
 	void put(const(dchar)[] elems) { foreach( ch; elems ) put(ch); }
 
-	private void writeToStream(in ubyte[] bytes)
+	private void writeToStream(scope const(ubyte)[] bytes)
 	{
 		// if the write fails, do not attempt another write in the destructor
 		// to avoid throwing an exception twice or nested


### PR DESCRIPTION
Deprecation showed up when I did `dub test`.