### PR TITLE
Reverse the vibe-core 1.x.x/2.x.x test configurations.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,8 +26,9 @@ jobs:
           - { parts: 'builds,unittests,examples,tests', extra_dflags: '' }
           # Custom part for coverage
           - { dc: dmd-latest, parts: 'unittests,tests', extra_dflags: "-cov -version=VibedSetCoverageMerge" }
-          # Custom part for vibe-core 2.x.x testing
-          - { dc: dmd-latest, parts: 'unittests,tests,vibe-core-2', extra_dflags: '' }
+          # Custom part for vibe-core 1.x.x testing
+          - { dc: dmd-latest, parts: 'unittests,tests,vibe-core-1', extra_dflags: '' }
+          - { dc: dmd-latest, parts: 'unittests,tests', extra_dflags: '' }
 
     runs-on: ${{ matrix.os }}
     timeout-minutes: 60

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-latest ]
+        os:
+          - ubuntu-latest
         dc:
           - dmd-latest
           - dmd-2.097.1
@@ -21,14 +22,15 @@ jobs:
           - ldc-1.26.0
           - ldc-1.23.0
           - ldc-1.21.0
+        parts:
+          - 'builds,unittests,examples,tests'
+        extra_dflags:
+          - ''
         include:
-          # Default
-          - { parts: 'builds,unittests,examples,tests', extra_dflags: '' }
           # Custom part for coverage
-          - { dc: dmd-latest, parts: 'unittests,tests', extra_dflags: "-cov -version=VibedSetCoverageMerge" }
+          - { os: ubuntu-latest, dc: dmd-latest, parts: 'unittests,tests', extra_dflags: "-cov -version=VibedSetCoverageMerge" }
           # Custom part for vibe-core 1.x.x testing
-          - { dc: dmd-latest, parts: 'unittests,tests,vibe-core-1', extra_dflags: '' }
-          - { dc: dmd-latest, parts: 'unittests,tests', extra_dflags: '' }
+          - { os: ubuntu-latest, dc: dmd-latest, parts: 'builds,unittests,tests,vibe-core-1', extra_dflags: '' }
 
     runs-on: ${{ matrix.os }}
     timeout-minutes: 60

--- a/examples/bench-http-server/source/app.d
+++ b/examples/bench-http-server/source/app.d
@@ -69,30 +69,32 @@ int main(string[] args)
 	//setLogLevel(LogLevel.Trace);
 	data = generateData();
 
-	runWorkerTaskDist({
-		auto settings = new HTTPServerSettings;
-		settings.port = 8080;
-		settings.bindAddresses = ["127.0.0.1"];
-		settings.options = HTTPServerOption.reusePort;
-		//settings.accessLogToConsole = true;
+	runWorkerTaskDist(() nothrow {
+		try {
+			auto settings = new HTTPServerSettings;
+			settings.port = 8080;
+			settings.bindAddresses = ["127.0.0.1"];
+			settings.options = HTTPServerOption.reusePort;
+			//settings.accessLogToConsole = true;
 
-		auto fsettings = new HTTPFileServerSettings;
-		fsettings.serverPathPrefix = "/file";
+			auto fsettings = new HTTPFileServerSettings;
+			fsettings.serverPathPrefix = "/file";
 
-		auto routes = new URLRouter;
-		routes.get("/", staticTemplate!"home.dt");
-		routes.get("/empty", &empty);
-		routes.get("/static/10", &static_10);
-		routes.get("/static/1k", &static_1k);
-		routes.get("/static/10k", &static_10k);
-		routes.get("/static/100k", &static_100k);
-		routes.get("/quit", &quit);
-		routes.get("/file/*", serveStaticFiles("./public", fsettings));
-		routes.rebuild();
+			auto routes = new URLRouter;
+			routes.get("/", staticTemplate!"home.dt");
+			routes.get("/empty", &empty);
+			routes.get("/static/10", &static_10);
+			routes.get("/static/1k", &static_1k);
+			routes.get("/static/10k", &static_10k);
+			routes.get("/static/100k", &static_100k);
+			routes.get("/quit", &quit);
+			routes.get("/file/*", serveStaticFiles("./public", fsettings));
+			routes.rebuild();
 
-		auto httpListener = listenHTTP(settings, routes);
-		auto tcpListener  = listenTCP(8081, toDelegate(&staticAnswer),
-			"127.0.0.1", TCPListenOptions.reusePort);
+			auto httpListener = listenHTTP(settings, routes);
+			auto tcpListener  = listenTCP(8081, toDelegate(&staticAnswer),
+				"127.0.0.1", TCPListenOptions.reusePort);
+		} catch (Exception e) assert(false, e.msg);
 	});
 
 	return runApplication(&args);

--- a/examples/read_write_mutex/source/app.d
+++ b/examples/read_write_mutex/source/app.d
@@ -66,15 +66,17 @@ int main(string[] args)
 
 	runWorkerTaskDist({
 		import core.thread : Thread; logInfo("Listen on thread %s", Thread.getThis().name);
-		auto routes = new URLRouter;
-		registerRestInterface(routes, new RestInterfaceImplementation());
+		try {
+			auto routes = new URLRouter;
+			registerRestInterface(routes, new RestInterfaceImplementation());
 
-		auto settings = new HTTPServerSettings();
-		settings.port = 8080;
-		settings.options = HTTPServerOption.reusePort;
-		settings.bindAddresses = ["::1", "127.0.0.1"];
+			auto settings = new HTTPServerSettings();
+			settings.port = 8080;
+			settings.options = HTTPServerOption.reusePort;
+			settings.bindAddresses = ["::1", "127.0.0.1"];
 
-		listenHTTP(settings, routes);
+			listenHTTP(settings, routes);
+		} catch (Exception e) assert(false, e.msg);
 	});
 
 	//Wait for a couple of seconds for the server to be initialized properly and then start

--- a/examples/redis-pubsub/source/app.d
+++ b/examples/redis-pubsub/source/app.d
@@ -26,9 +26,11 @@ int main(string[] args)
 	publisher.getDatabase(0).publish("test2", "Hello from Channel 2");
 
 	auto taskHandler = runTask({
-		subscriber.subscribe("test-fiber");
-		publisher.getDatabase(0).publish("test-fiber", "Hello from the Fiber!");
-		subscriber.unsubscribe();
+		try {
+			subscriber.subscribe("test-fiber");
+			publisher.getDatabase(0).publish("test-fiber", "Hello from the Fiber!");
+			subscriber.unsubscribe();
+		} catch (Exception e) assert(false, e.msg);
 	});
 
 	return runApplication(&args);

--- a/examples/rest-collections/source/app.d
+++ b/examples/rest-collections/source/app.d
@@ -94,20 +94,22 @@ int main(string[] args)
 	auto listener = listenHTTP(settings, router);
 
 	auto taskHandler = runTask({
-		auto api = new RestInterfaceClient!ForumAPI("http://127.0.0.1:8080/");
-		logInfo("Current number of threads: %s", api.threads.get().length);
-		logInfo("Posting a topic...");
-		api.threads.post("RESTful services", "Hi, just wanted to post something!");
-		logInfo("Posting a reply...");
-		api.threads["RESTful services"].posts.post("Okay, but what do you actually want to say?");
-		logInfo("New list of threads:");
-		foreach (th; api.threads.get) {
-			import std.array : replicate;
-			logInfo("\n%s\n%s", th, "=".replicate(th.length));
-			foreach (m; api.threads[th].posts.get)
-				logInfo("%s\n---", m);
-		}
-		logInfo("Leaving REST server running. Hit Ctrl+C to exit.");
+		try {
+			auto api = new RestInterfaceClient!ForumAPI("http://127.0.0.1:8080/");
+			logInfo("Current number of threads: %s", api.threads.get().length);
+			logInfo("Posting a topic...");
+			api.threads.post("RESTful services", "Hi, just wanted to post something!");
+			logInfo("Posting a reply...");
+			api.threads["RESTful services"].posts.post("Okay, but what do you actually want to say?");
+			logInfo("New list of threads:");
+			foreach (th; api.threads.get) {
+				import std.array : replicate;
+				logInfo("\n%s\n%s", th, "=".replicate(th.length));
+				foreach (m; api.threads[th].posts.get)
+					logInfo("%s\n---", m);
+			}
+			logInfo("Leaving REST server running. Hit Ctrl+C to exit.");
+		} catch (Exception e) assert(false, e.msg);
 	});
 
 	return runApplication(&args);

--- a/examples/task_control/source/app.d
+++ b/examples/task_control/source/app.d
@@ -26,13 +26,14 @@ int main(string[] args)
 {
 	g_task = runTask({
 		logInfo("Starting task, waiting for max. 10 seconds.");
-		sleep(dur!"seconds"(10));
+		try sleep(dur!"seconds"(10));
+		catch (Exception e) logInfo("Task interrupted");
 		logInfo("Exiting task after 10 seconds.");
 	});
 
 	runTask({
 		logInfo("Monitor task started. Waiting for first task to end.");
-		g_task.join();
+		g_task.joinUninterruptible();
 		logInfo("Task has finished.");
 	});
 

--- a/examples/uploader/source/app.d
+++ b/examples/uploader/source/app.d
@@ -13,11 +13,11 @@ void uploadFile(scope HTTPServerRequest req, scope HTTPServerResponse res)
 {
 	auto pf = "file" in req.files;
 	enforce(pf !is null, "No file uploaded!");
-	try moveFile(pf.tempPath, Path(".") ~ pf.filename);
+	try moveFile(pf.tempPath, NativePath(".") ~ pf.filename);
 	catch (Exception e) {
 		logWarn("Failed to move file to destination folder: %s", e.msg);
 		logInfo("Performing copy+delete instead.");
-		copyFile(pf.tempPath, Path(".") ~ pf.filename);
+		copyFile(pf.tempPath, NativePath(".") ~ pf.filename);
 	}
 
 	res.writeBody("File uploaded!", "text/plain");

--- a/run-ci.sh
+++ b/run-ci.sh
@@ -7,9 +7,9 @@ DUB_ARGS="--build-mode=${DUB_BUILD_MODE:-separate} ${DUB_ARGS:-}"
 : ${PARTS:=lint,builds,unittests,examples,tests,mongo,meson}
 
 # force selecting vibe-core 2.x.x
-if [[ $PARTS =~ (^|,)vibe-core-2(,|$) ]]; then
+if [[ $PARTS =~ (^|,)vibe-core-1(,|$) ]]; then
     RECIPES=`find | grep dub.sdl`
-    sed -i "s/\"vibe-core\" version=\">=1\.0\.0 <3\.0\.0-0\"/\"vibe-core\" version=\">=2.0.0-0 <3.0.0-0\"/g" $RECIPES
+    sed -i "s/\"vibe-core\" version=\">=1\.0\.0 <3\.0\.0-0\"/\"vibe-core\" version=\">=1.0.0 <2.0.0-0\"/g" $RECIPES
 fi
 
 if [[ $PARTS =~ (^|,)lint(,|$) ]]; then

--- a/tests/std.concurrency/source/app.d
+++ b/tests/std.concurrency/source/app.d
@@ -14,7 +14,7 @@ void main()
 	t1 = spawn({
 		// ensure that asynchronous operations run in parallel to receive()
 		int wc = 0;
-		runTask({ while (true) { sleep(250.msecs); wc++; logInfo("Watchdog receiver %s", wc); } });
+		runTask({ while (true) { sleepUninterruptible(250.msecs); wc++; logInfo("Watchdog receiver %s", wc); } });
 
 		bool finished = false;
 		try while (!finished) {


### PR DESCRIPTION
Now that vibe-core 2.0.0 is tagged, it will be chosen by default, so we need to force testing 1.x.x.

This revealed a few issues in the build matrix and some additional compile errors in the example projects that need to be fixed.