### PR TITLE
Fix duplicate database name in namespace for MongoDB cursor getMore calls

### DIFF
--- a/mongodb/vibe/db/mongo/cursor.d
+++ b/mongodb/vibe/db/mongo/cursor.d
@@ -13,11 +13,12 @@ public import vibe.db.mongo.impl.crud;
 import vibe.db.mongo.connection;
 import vibe.db.mongo.client;
 
-import std.array : array;
-import std.algorithm : map, max, min;
-import std.exception;
-
 import core.time;
+import std.array : array;
+import std.algorithm : map, max, min, skipOver;
+import std.exception;
+import std.range : chain;
+
 
 /**
 	Represents a cursor for a MongoDB query.
@@ -515,6 +516,10 @@ private class MongoFindCursor(DocType) : IMongoCursorData!DocType {
 	final void handleReply(long id, string ns, size_t count)
 	{
 		m_cursor = id;
+		// The qualified collection name is reported here, but when requesting
+		// data, we need to send the database name and the collection name
+		// separately, so we have to remove the database prefix:
+		ns.skipOver(m_database.chain("."));
 		m_collection = ns;
 		m_documents.length = count;
 		m_readDoc = 0;

--- a/tests/mongodb/cursor/dub.json
+++ b/tests/mongodb/cursor/dub.json
@@ -1,0 +1,7 @@
+{
+    "name": "tests",
+    "description": "High level MongoDB test for vibe.d",
+    "dependencies": {
+        "vibe-d:mongodb": {"path": "../../../"}
+    }
+}

--- a/tests/mongodb/cursor/source/app.d
+++ b/tests/mongodb/cursor/source/app.d
@@ -1,0 +1,42 @@
+/// Requires mongo service running on localhost with default port
+/// Uses test database
+
+module app;
+
+import vibe.core.core;
+import vibe.core.log;
+import vibe.data.bson;
+import vibe.db.mongo.mongo;
+
+import std.conv : to;
+
+
+void runTest(ushort port)
+{
+	MongoClient client = connectMongoDB("127.0.0.1", port);
+
+	auto coll = client.getCollection("test.collection");
+	coll.deleteAll();
+
+	foreach (i; 0 .. 100)
+		coll.insertOne(["idx": i]);
+
+	FindOptions opts;
+	opts.batchSize = 10;
+	auto data = coll.find(Bson.emptyObject, opts);
+	size_t i = 0;
+	foreach (d; data)
+		assert(d["idx"].get!int == i++);
+	assert(i == 100);
+
+	coll.deleteAll();
+}
+
+void main(string[] args)
+{
+	int ret = 0;
+	ushort port = args.length > 1
+		? args[1].to!ushort
+		: MongoClientSettings.defaultPort;
+	runTest(port);
+}


### PR DESCRIPTION
Fixes a regression introduced by the revamped MongoDB driver.