### PR TITLE
Force all TLS related code to be stripped for the notls configuration

### DIFF
--- a/tls/dub.sdl
+++ b/tls/dub.sdl
@@ -54,4 +54,5 @@ configuration "openssl-static" {
 }
 
 configuration "notls" {
+	versions "VibeNoSSL"
 }

--- a/tls/vibe/stream/botan.d
+++ b/tls/vibe/stream/botan.d
@@ -6,7 +6,8 @@
 */
 module vibe.stream.botan;
 
-version(Have_botan):
+version (VibeNoSSL) {}
+else version(Have_botan):
 
 version = X509;
 import botan.constants;

--- a/tls/vibe/stream/openssl.d
+++ b/tls/vibe/stream/openssl.d
@@ -6,7 +6,10 @@
 	Authors: Sönke Ludwig
 */
 module vibe.stream.openssl;
-version(Have_openssl):
+
+version (VibeNoSSL) {}
+else version(Have_openssl):
+
 import vibe.core.log;
 import vibe.core.net;
 import vibe.core.stream;


### PR DESCRIPTION
Fixes a bogus dependency to the openssl dynamic libraries after the latest package recipe refactoring w.r.t. the new static configuration. By setting "VibeNoSSL", this also strips TLS code in the HTTP server.