### PR TITLE
mongo updateimpl: check update, not field for updates

### DIFF
--- a/mongodb/vibe/db/mongo/collection.d
+++ b/mongodb/vibe/db/mongo/collection.d
@@ -342,12 +342,13 @@ struct MongoCollection {
 					// however in debug mode we check the full document, as we can give better error messages to the dev
 				}
 			}
+			auto ubson = serializeToBson(documents[i]);
 			if (mustBeModification)
 			{
-				if (qbson.type == Bson.Type.object)
+				if (ubson.type == Bson.Type.object)
 				{
 					bool anyDollar = false;
-					foreach (string k, v; qbson.byKeyValue)
+					foreach (string k, v; ubson.byKeyValue)
 					{
 						if (k.startsWith("$"))
 							anyDollar = true;
@@ -362,7 +363,7 @@ struct MongoCollection {
 							~ "(this update call would otherwise replace the entire matched object with the passed in update object)");
 				}
 			}
-			updateBson["u"] = serializeToBson(documents[i]);
+			updateBson["u"] = ubson;
 			foreach (string k, v; optionsBson.byKeyValue)
 				if (k.among!FieldsMovedIntoChildren)
 					updateBson[k] = v;
@@ -381,8 +382,10 @@ struct MongoCollection {
 		if (upserted.length)
 		{
 			ret.upsertedIds.length = upserted.length;
-			foreach (i, id; upserted)
-				ret.upsertedIds[i] = id.get!BsonObjectID;
+			foreach (i, upsert; upserted)
+            {
+				ret.upsertedIds[i] = upsert["_id"].get!BsonObjectID;
+            }
 		}
 		return ret;
 	}

--- a/mongodb/vibe/db/mongo/collection.d
+++ b/mongodb/vibe/db/mongo/collection.d
@@ -326,23 +326,23 @@ struct MongoCollection {
 			auto updateBson = Bson.emptyObject;
 			auto qbson = serializeToBson(q);
 			updateBson["q"] = qbson;
+			auto ubson = serializeToBson(documents[i]);
 			if (mustBeDocument)
 			{
-				if (qbson.type != Bson.Type.object)
+				if (ubson.type != Bson.Type.object)
 					assert(false, "Passed in non-document into a place where only replacements are expected. "
 						~ "Maybe you want to call updateOne or updateMany instead?");
 
-				foreach (string k, v; qbson.byKeyValue)
+				foreach (string k, v; ubson.byKeyValue)
 				{
 					if (k.startsWith("$"))
 						assert(false, "Passed in atomic modifiers (" ~ k
 							~ ") into a place where only replacements are expected. "
 							~ "Maybe you want to call updateOne or updateMany instead?");
-					debug break; // server checks that the rest is consistent (only $ or only non-$ allowed)
-					// however in debug mode we check the full document, as we can give better error messages to the dev
+					debug {} // server checks that the rest is consistent (only $ or only non-$ allowed)
+					else break; // however in debug mode we check the full document, as we can give better error messages to the dev
 				}
 			}
-			auto ubson = serializeToBson(documents[i]);
 			if (mustBeModification)
 			{
 				if (ubson.type == Bson.Type.object)
@@ -352,8 +352,8 @@ struct MongoCollection {
 					{
 						if (k.startsWith("$"))
 							anyDollar = true;
-						debug break; // server checks that the rest is consistent (only $ or only non-$ allowed)
-						// however in debug mode we check the full document, as we can give better error messages to the dev
+						debug {} // server checks that the rest is consistent (only $ or only non-$ allowed)
+                        else break; // however in debug mode we check the full document, as we can give better error messages to the dev
 						// also nice side effect: if this is an empty document, this also matches the assert(false) branch.
 					}
 

--- a/tests/mongodb/_connection/source/app.d
+++ b/tests/mongodb/_connection/source/app.d
@@ -157,6 +157,21 @@ int main(string[] args)
 		.map!(c => c["name"].get!string)
 		.equal(["collection"]));
 
+    auto options = UpdateOptions();
+    options.upsert = true;
+
+    //test updateOne
+    auto newID = BsonObjectID.generate;
+    foreach(const str; ["a", "b", "c"])
+    {
+        coll.updateOne(["_id": newID], ["$push" : ["array" : str ]], options);
+    }
+
+    auto arrResult = coll.findOne(["_id" : newID])["array"];
+    assert(arrResult[0].get!string =="a");
+    assert(arrResult[1].get!string =="b");
+    assert(arrResult[2].get!string =="c");
+
 	coll.drop();
 
 	assert(db.runListCommand(["listCollections": Bson(1.0)])

--- a/tests/mongodb/_connection/source/app.d
+++ b/tests/mongodb/_connection/source/app.d
@@ -5,6 +5,7 @@ import vibe.core.log;
 import core.time;
 import std.algorithm;
 import std.conv;
+import core.exception : AssertError;
 import std.exception;
 
 int main(string[] args)
@@ -157,20 +158,24 @@ int main(string[] args)
 		.map!(c => c["name"].get!string)
 		.equal(["collection"]));
 
-    auto options = UpdateOptions();
-    options.upsert = true;
+	auto options = UpdateOptions();
+	options.upsert = true;
 
-    //test updateOne
-    auto newID = BsonObjectID.generate;
-    foreach(const str; ["a", "b", "c"])
-    {
-        coll.updateOne(["_id": newID], ["$push" : ["array" : str ]], options);
-    }
+	//test updateOne
+	auto newID = BsonObjectID.generate;
+	foreach(const str; ["a", "b", "c"])
+	{
+		coll.updateOne(["_id": newID], ["$push" : ["array" : str ]], options);
+	}
 
-    auto arrResult = coll.findOne(["_id" : newID])["array"];
-    assert(arrResult[0].get!string =="a");
-    assert(arrResult[1].get!string =="b");
-    assert(arrResult[2].get!string =="c");
+	auto arrResult = coll.findOne(["_id" : newID])["array"];
+	assert(arrResult[0].get!string =="a");
+	assert(arrResult[1].get!string =="b");
+	assert(arrResult[2].get!string =="c");
+
+	assertThrown!AssertError(coll.updateOne(["_id": newID], ["this is a replacement": "which is not allowed here"]));
+	assertThrown!AssertError(coll.replaceOne(["_id": newID], ["$updateOp": "is not allowed here"]));
+	assertThrown!AssertError(coll.replaceOne(["_id": newID], null));
 
 	coll.drop();
 


### PR DESCRIPTION
I'm not sure about this fix since I'm not at all a mongo expert, but this does seem in line with the documentation for what update commands should look like.  Figured this was a good starting point.