### PR TITLE
meson.build update to support modern Meson versions

### DIFF
--- a/crypto/meson.build
+++ b/crypto/meson.build
@@ -2,10 +2,9 @@
 
 vibe_crypto_src_dir = include_directories('.')
 
-vibe_crypto_src = [
+vibe_crypto_src = files(
     'vibe/crypto/cryptorand.d',
-    'vibe/crypto/passwordhash.d'
-]
+)
 
 #
 # Install Includes
@@ -44,7 +43,7 @@ vibe_crypto_dep = declare_dependency(
 vibe_test_crypto_exe = executable('vibe-test_crypto',
     [vibe_crypto_src],
     dependencies: [vibe_core_dep],
-    d_args: meson.get_compiler('d').unittest_args(),
+    d_unittest: true,
     link_args: '-main'
 )
 test('vibe-test_crypto', vibe_test_crypto_exe)

--- a/data/meson.build
+++ b/data/meson.build
@@ -47,7 +47,7 @@ vibe_test_data_exe = executable('vibe-test_data',
     [vibe_data_src],
     include_directories: [vibe_utils_src_dir],
     dependencies: [vibe_utils_dep],
-    d_args: meson.get_compiler('d').unittest_args(),
+    d_unittest: true,
     link_args: '-main'
 )
 test('vibe-test_data', vibe_test_data_exe)

--- a/http/meson.build
+++ b/http/meson.build
@@ -69,7 +69,7 @@ vibe_test_http_exe = executable('vibe-test_http',
                    vibe_tls_dep,
                    vibe_crypto_dep,
                    diet_dep],
-    d_args: meson.get_compiler('d').unittest_args(),
+    d_unittest: true,
     link_args: '-main'
 )
 test('vibe-test_http', vibe_test_http_exe)

--- a/http/meson.build
+++ b/http/meson.build
@@ -8,6 +8,7 @@ vibe_http_src = [
     'vibe/http/client.d',
     'vibe/http/common.d',
     'vibe/http/dist.d',
+    'vibe/http/internal/basic_auth_client.d',
     'vibe/http/fileserver.d',
     'vibe/http/form.d',
     'vibe/http/log.d',

--- a/inet/meson.build
+++ b/inet/meson.build
@@ -2,14 +2,13 @@
 
 vibe_inet_src_dir = include_directories('.')
 
-vibe_inet_src = [
+vibe_inet_src = files(
     'vibe/inet/message.d',
     'vibe/inet/mimetypes.d',
-    'vibe/inet/path.d',
     'vibe/inet/url.d',
     'vibe/inet/urltransfer.d',
     'vibe/inet/webform.d',
-]
+)
 
 #
 # Install Includes
@@ -20,11 +19,17 @@ install_subdir('vibe/', install_dir: 'include/d/vibe/')
 # Build Targets
 #
 
+vibe_inet_deps = [
+    vibe_data_dep,
+    vibe_core_dep,
+    vibe_stream_dep,
+    vibe_textfilter_dep,
+]
+
 # Internet standard functionality
 vibe_inet_lib = library('vibe-inet',
         [vibe_inet_src],
-        dependencies: [vibe_stream_dep,
-                       vibe_textfilter_dep],
+        dependencies: vibe_inet_deps,
         install: true,
         version: project_version,
         soversion: project_soversion
@@ -40,8 +45,7 @@ pkgc.generate(name: 'vibe-inet',
 vibe_inet_dep = declare_dependency(
     link_with: [vibe_inet_lib],
     include_directories: [vibe_inet_src_dir],
-    dependencies: [vibe_stream_dep,
-                   vibe_textfilter_dep],
+    dependencies: vibe_inet_deps,
 )
 
 #
@@ -49,9 +53,8 @@ vibe_inet_dep = declare_dependency(
 #
 vibe_test_inet_exe = executable('vibe-test_inet',
     [vibe_inet_src],
-    dependencies: [vibe_stream_dep,
-                   vibe_textfilter_dep],
-    d_args: meson.get_compiler('d').unittest_args(),
+    dependencies: vibe_inet_deps,
+    d_unittest: true,
     link_args: '-main'
 )
 test('vibe-test_inet', vibe_test_inet_exe)

--- a/lib/subprojects/eventcore.wrap
+++ b/lib/subprojects/eventcore.wrap
@@ -1,0 +1,3 @@
+[wrap-git]
+url=https://github.com/vibe-d/eventcore.git
+revision=head

--- a/lib/subprojects/taggedalgebraic.wrap
+++ b/lib/subprojects/taggedalgebraic.wrap
@@ -1,0 +1,3 @@
+[wrap-git]
+url=https://github.com/s-ludwig/taggedalgebraic.git
+revision=head

--- a/lib/subprojects/vibe-core.wrap
+++ b/lib/subprojects/vibe-core.wrap
@@ -1,0 +1,3 @@
+[wrap-git]
+url=https://github.com/vibe-d/vibe-core.git
+revision=head

--- a/mail/meson.build
+++ b/mail/meson.build
@@ -46,7 +46,7 @@ vibe_test_mail_exe = executable('vibe-test_mail',
     [vibe_mail_src],
     dependencies: [vibe_inet_dep,
                    vibe_tls_dep],
-    d_args: meson.get_compiler('d').unittest_args(),
+    d_unittest: true,
     link_args: '-main'
 )
 test('vibe-test_mail', vibe_test_mail_exe)

--- a/meson.build
+++ b/meson.build
@@ -76,6 +76,8 @@ else
 endif
 openssl_inc = include_directories(openssl_src_dir)
 
+vibe_core_dep = dependency('vibe-core')
+
 #
 # Modules
 #

--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,4 @@
 project('Vibe.d', 'd',
-    meson_version: '>=0.40',
     subproject_dir: 'lib/subprojects',
     license: 'MIT',
     version: '0.9.7'

--- a/mongodb/meson.build
+++ b/mongodb/meson.build
@@ -61,7 +61,7 @@ vibe_test_mongodb_exe = executable('vibe-test_mongodb',
                    vibe_inet_dep,
                    vibe_tls_dep,
                    vibe_crypto_dep],
-    d_args: meson.get_compiler('d').unittest_args(),
+    d_unittest: true,
     link_args: '-main'
 )
 test('vibe-test_mongodb', vibe_test_mongodb_exe)

--- a/mongodb/meson.build
+++ b/mongodb/meson.build
@@ -9,6 +9,8 @@ vibe_mongodb_src = [
     'vibe/db/mongo/cursor.d',
     'vibe/db/mongo/database.d',
     'vibe/db/mongo/flags.d',
+    'vibe/db/mongo/impl/crud.d',
+    'vibe/db/mongo/impl/index.d',
     'vibe/db/mongo/mongo.d',
     'vibe/db/mongo/sasl.d',
     'vibe/db/mongo/sessionstore.d',
@@ -24,13 +26,17 @@ install_subdir('vibe/', install_dir: 'include/d/vibe/')
 # Build Targets
 #
 
+vibe_mongodb_deps = [
+    vibe_http_dep,
+    vibe_inet_dep,
+    vibe_tls_dep,
+    vibe_crypto_dep,
+]
+
 # MongoDB database client implementation
 vibe_mongodb_lib = library('vibe-mongodb',
         [vibe_mongodb_src],
-        dependencies: [vibe_http_dep,
-                       vibe_inet_dep,
-                       vibe_tls_dep,
-                       vibe_crypto_dep],
+        dependencies: vibe_mongodb_deps,
         install: true,
         version: project_version,
         soversion: project_soversion
@@ -46,10 +52,7 @@ pkgc.generate(name: 'vibe-mongodb',
 vibe_mongodb_dep = declare_dependency(
     link_with: [vibe_mongodb_lib],
     include_directories: [vibe_mongodb_src_dir],
-    dependencies: [vibe_http_dep,
-                   vibe_inet_dep,
-                   vibe_tls_dep,
-                   vibe_crypto_dep],
+    dependencies: vibe_mongodb_deps,
 )
 
 #
@@ -57,10 +60,7 @@ vibe_mongodb_dep = declare_dependency(
 #
 vibe_test_mongodb_exe = executable('vibe-test_mongodb',
     [vibe_mongodb_src],
-    dependencies: [vibe_http_dep,
-                   vibe_inet_dep,
-                   vibe_tls_dep,
-                   vibe_crypto_dep],
+    dependencies: vibe_mongodb_deps,
     d_unittest: true,
     link_args: '-main'
 )

--- a/redis/meson.build
+++ b/redis/meson.build
@@ -46,7 +46,7 @@ vibe_redis_dep = declare_dependency(
 vibe_test_redis_exe = executable('vibe-test_redis',
     [vibe_redis_src],
     dependencies: [vibe_http_dep],
-    d_args: meson.get_compiler('d').unittest_args(),
+    d_unittest: true,
     link_args: '-main'
 )
 test('vibe-test_redis', vibe_test_redis_exe)

--- a/redis/meson.build
+++ b/redis/meson.build
@@ -18,10 +18,12 @@ install_subdir('vibe/', install_dir: 'include/d/vibe/')
 # Build Targets
 #
 
+redis_deps = [vibe_http_dep, vibe_core_dep]
+
 # Redis database client implementation
 vibe_redis_lib = library('vibe-redis',
         [vibe_redis_src],
-        dependencies: [vibe_http_dep],
+        dependencies: redis_deps,
         install: true,
         version: project_version,
         soversion: project_soversion
@@ -37,7 +39,6 @@ pkgc.generate(name: 'vibe-redis',
 vibe_redis_dep = declare_dependency(
     link_with: [vibe_redis_lib],
     include_directories: [vibe_redis_src_dir],
-    dependencies: [vibe_http_dep],
 )
 
 #
@@ -45,7 +46,7 @@ vibe_redis_dep = declare_dependency(
 #
 vibe_test_redis_exe = executable('vibe-test_redis',
     [vibe_redis_src],
-    dependencies: [vibe_http_dep],
+    dependencies: redis_deps,
     d_unittest: true,
     link_args: '-main'
 )

--- a/stream/meson.build
+++ b/stream/meson.build
@@ -26,7 +26,7 @@ install_subdir('vibe/', install_dir: 'include/d/vibe/')
 # Cryptographic helper routines
 vibe_stream_lib = library('vibe-stream',
         [vibe_stream_src],
-        dependencies: [vibe_core_dep],
+        dependencies: [vibe_core_dep, vibe_utils_dep],
         install: true,
         version: project_version,
         soversion: project_soversion
@@ -42,14 +42,14 @@ pkgc.generate(name: 'vibe-stream',
 vibe_stream_dep = declare_dependency(
     link_with: [vibe_stream_lib],
     include_directories: [vibe_stream_src_dir],
-    dependencies: [vibe_core_dep]
+    dependencies: [vibe_core_dep, vibe_utils_dep]
 )
 #
 # Tests
 #
 vibe_test_stream_exe = executable('vibe-test_stream',
     [vibe_stream_src],
-    dependencies: [vibe_core_dep],
+    dependencies: [vibe_core_dep, vibe_utils_dep],
     d_unittest: true,
     link_args: '-main'
 )

--- a/stream/meson.build
+++ b/stream/meson.build
@@ -50,7 +50,7 @@ vibe_stream_dep = declare_dependency(
 vibe_test_stream_exe = executable('vibe-test_stream',
     [vibe_stream_src],
     dependencies: [vibe_core_dep],
-    d_args: meson.get_compiler('d').unittest_args(),
+    d_unittest: true,
     link_args: '-main'
 )
 test('vibe-test_stream', vibe_test_stream_exe)

--- a/textfilter/meson.build
+++ b/textfilter/meson.build
@@ -45,7 +45,7 @@ vibe_textfilter_dep = declare_dependency(
 vibe_test_textfilter_exe = executable('vibe-test_textfilter',
     [vibe_textfilter_src],
     dependencies: [vibe_core_dep],
-    d_args: meson.get_compiler('d').unittest_args(),
+    d_unittest: true,
     link_args: '-main'
 )
 test('vibe-test_textfilter', vibe_test_textfilter_exe)

--- a/textfilter/meson.build
+++ b/textfilter/meson.build
@@ -20,7 +20,7 @@ install_subdir('vibe/', install_dir: 'include/d/vibe/')
 # Text filtering routines
 vibe_textfilter_lib = library('vibe-textfilter',
         [vibe_textfilter_src],
-        dependencies: [vibe_core_dep],
+        dependencies: [vibe_core_dep, vibe_utils_dep],
         install: true,
         version: project_version,
         soversion: project_soversion
@@ -36,7 +36,7 @@ pkgc.generate(name: 'vibe-textfilter',
 vibe_textfilter_dep = declare_dependency(
     link_with: [vibe_textfilter_lib],
     include_directories: [vibe_textfilter_src_dir],
-    dependencies: [vibe_core_dep],
+    dependencies: [vibe_core_dep, vibe_utils_dep],
 )
 
 #
@@ -44,7 +44,7 @@ vibe_textfilter_dep = declare_dependency(
 #
 vibe_test_textfilter_exe = executable('vibe-test_textfilter',
     [vibe_textfilter_src],
-    dependencies: [vibe_core_dep],
+    dependencies: [vibe_core_dep, vibe_utils_dep],
     d_unittest: true,
     link_args: '-main'
 )

--- a/tls/meson.build
+++ b/tls/meson.build
@@ -45,7 +45,7 @@ vibe_tls_dep = declare_dependency(
 vibe_test_tls_exe = executable('vibe-test_tls',
     [vibe_tls_src],
     dependencies: [vibe_stream_dep],
-    d_args: meson.get_compiler('d').unittest_args(),
+    d_unittest: true,
     link_args: '-main'
 )
 test('vibe-test_tls', vibe_test_tls_exe)

--- a/tls/meson.build
+++ b/tls/meson.build
@@ -17,10 +17,13 @@ install_subdir('vibe/', install_dir: 'include/d/vibe/')
 # Build Targets
 #
 
+d_versions = ['VibeNoSSL']
+
 # TLS stream implementations
 vibe_tls_lib = library('vibe-tls',
         [vibe_tls_src],
         dependencies: [vibe_stream_dep],
+        d_module_versions: d_versions,
         install: true,
         version: project_version,
         soversion: project_soversion
@@ -35,6 +38,7 @@ pkgc.generate(name: 'vibe-tls',
 
 vibe_tls_dep = declare_dependency(
     link_with: [vibe_tls_lib],
+    d_module_versions: d_versions,
     include_directories: [vibe_tls_src_dir],
     dependencies: [vibe_stream_dep]
 )
@@ -45,6 +49,7 @@ vibe_tls_dep = declare_dependency(
 vibe_test_tls_exe = executable('vibe-test_tls',
     [vibe_tls_src],
     dependencies: [vibe_stream_dep],
+    d_module_versions: d_versions,
     d_unittest: true,
     link_args: '-main'
 )

--- a/utils/meson.build
+++ b/utils/meson.build
@@ -2,7 +2,7 @@
 
 vibe_utils_src_dir = include_directories('.')
 
-vibe_utils_src = [
+vibe_utils_src = files(
     'vibe/internal/memory_legacy.d',
     'vibe/internal/meta/all.d',
     'vibe/internal/meta/codegen.d',
@@ -15,10 +15,9 @@ vibe_utils_src = [
     'vibe/utils/array.d',
     'vibe/utils/dictionarylist.d',
     'vibe/utils/hashmap.d',
-    'vibe/utils/memory.d',
     'vibe/utils/string.d',
     'vibe/utils/validation.d',
-]
+)
 
 #
 # Install Includes
@@ -64,7 +63,7 @@ vibe_utils_dep = declare_dependency(
 vibe_test_utils_exe = executable('vibe-test_utils',
     [vibe_utils_src],
     dependencies: [vibe_utils_dep],
-    d_args: meson.get_compiler('d').unittest_args(),
+    d_unittest: true,
     link_args: '-main'
 )
 test('vibe-test_utils', vibe_test_utils_exe)

--- a/web/meson.build
+++ b/web/meson.build
@@ -50,7 +50,7 @@ vibe_web_dep = declare_dependency(
 vibe_test_web_exe = executable('vibe-test_web',
     [vibe_web_src],
     dependencies: [vibe_http_dep],
-    d_args: meson.get_compiler('d').unittest_args(),
+    d_unittest: true,
     link_args: '-main'
 )
 test('vibe-test_web', vibe_test_web_exe)


### PR DESCRIPTION
I don't know if anyone currently using Meson for build Vibe.d, but it has clearly not been able to build on the latest Meson versions. However, I see changes being made to the Meson files from time to time. Please tell how you use Meson builds?

Related PRs:
https://github.com/vibe-d/vibe-core/pull/356
https://github.com/vibe-d/eventcore/pull/221
