### PR TITLE
Remove support for non-safe REST methods

### DIFF
--- a/examples/rest-collections/source/api.d
+++ b/examples/rest-collections/source/api.d
@@ -4,11 +4,13 @@ module api;
 import vibe.web.rest;
 
 interface ForumAPI {
+	@safe:
 	// base path /threads/
 	Collection!ThreadAPI threads();
 }
 
 interface ThreadAPI {
+	@safe:
 	// define the index parameters used to identify the collection items
 	struct CollectionIndices {
 		string _thread_name;
@@ -27,6 +29,7 @@ interface ThreadAPI {
 }
 
 interface PostAPI {
+	@safe:
 	// define the index parameters used to identify the collection items
 	struct CollectionIndices {
 		string _thread_name;

--- a/tests/restclient/source/app.d
+++ b/tests/restclient/source/app.d
@@ -4,6 +4,7 @@ import vibe.vibe;
 
 interface ITestAPI
 {
+	@safe:
 	@property ISub sub();
 
 	@method(HTTPMethod.POST) @path("other/path")
@@ -22,6 +23,7 @@ interface ITestAPI
 }
 
 interface ISub {
+	@safe:
 	int get(int id);
 }
 
@@ -49,6 +51,7 @@ class SubAPI : ISub {
 
 interface ITestAPICors
 {
+	@safe:
 	string getFoo();
 	string setFoo();
 	string addFoo();


### PR DESCRIPTION
```
The deprecation has been introduced in v0.8.0, released 2017-07-10, over 6 years ago. The workaround also introduces some issues, as a closure is created (memory allocation) and it does not work for types with scoped destruction.
```

Deprecation introduced in https://github.com/vibe-d/vibe.d/commit/2d9967e23e24d2957651bd1228b5360e54ab7a16