### PR TITLE
Avoid possible array bounds error.

### DIFF
--- a/http/vibe/http/server.d
+++ b/http/vibe/http/server.d
@@ -2481,7 +2481,7 @@ private string formatRFC822DateAlloc(SysTime time)
 	static LAST = CacheTime(SysTime.min());
 
 	if (time > LAST.nextUpdate) {
-		auto app = new FixedAppender!(string, 29);
+		auto app = new FixedAppender!(string, 32);
 		writeRFC822DateTimeString(app, time);
 		LAST.update(time);
 		LAST.cachedDate = () @trusted { return app.data; } ();


### PR DESCRIPTION
RFC822 date/time strings can be larger than 29 characters if an unnamed time zone is used. Extending the buffer to 32 leaves one byte of slack for the longest possible string: "Wed, 02 Oct 2002 08:00:00 +0200"