### PR TITLE
fix MongoDB CRUD not throwing on error

### DIFF
--- a/mongodb/vibe/db/mongo/connection.d
+++ b/mongodb/vibe/db/mongo/connection.d
@@ -85,6 +85,7 @@ class MongoDriverException : MongoException
  * It does not indicate problem with vibe.d driver itself. Most frequently this
  * one is thrown when MongoConnection is in checked mode and getLastError() has something interesting.
  */
+deprecated("Check for MongoException instead - the modern write commands now throw MongoBulkWriteException on error")
 class MongoDBException : MongoException
 {
 @safe:
@@ -992,7 +993,7 @@ final class MongoConnection {
 	private void authenticate()
 	{
 		scope (failure) disconnect();
-	
+
 		string cn = m_settings.getAuthDatabase;
 
 		auto cmd = Bson(["getnonce": Bson(1)]);

--- a/mongodb/vibe/db/mongo/connection.d
+++ b/mongodb/vibe/db/mongo/connection.d
@@ -959,7 +959,7 @@ final class MongoConnection {
 
 	private int nextMessageId() { return m_msgid++; }
 
-	private void checkForError(string collection_name)
+	deprecated private void checkForError(string collection_name)
 	{
 		auto coll = collection_name.split(".")[0];
 		auto err = getLastError(coll);


### PR DESCRIPTION
e.g. index constraints failing wasn't throwing any exceptions anymore - now throws a sub-class of MongoException (not MongoDBException)