### PR TITLE
MongoDB: fix cursor destructors

### DIFF
--- a/mongodb/vibe/db/mongo/connection.d
+++ b/mongodb/vibe/db/mongo/connection.d
@@ -631,6 +631,10 @@ final class MongoConnection {
 		{
 			Bson command = Bson.emptyObject;
 			auto parts = collection.findSplit(".");
+			if (!parts[2].length)
+				throw new MongoDriverException(
+					"Attempted to call killCursors with non-fully-qualified collection name: '"
+					~ collection ~ "'");
 			command["killCursors"] = Bson(parts[2]);
 			command["cursors"] = () @trusted { return cursors; } ().serializeToBson; // NOTE: "escaping" scope here
 			runCommand!Bson(parts[0], command);


### PR DESCRIPTION
unsure how this hasn't triggered before - checked and fixed on MongoDB 7 now