### PR TITLE
Fix deserialization of string based enum types

### DIFF
--- a/mongodb/vibe/db/mongo/collection.d
+++ b/mongodb/vibe/db/mongo/collection.d
@@ -1477,7 +1477,7 @@ struct MaxWireVersion
 MaxWireVersion until(WireVersion v) @safe { return MaxWireVersion(v); }
 
 /// Unsets nullable fields not matching the server version as defined per UDAs.
-void enforceWireVersionConstraints(T)(ref T field, WireVersion serverVersion,
+void enforceWireVersionConstraints(T)(ref T field, int serverVersion,
 	string file = __FILE__, size_t line = __LINE__)
 @safe {
 	import std.traits : getUDAs;

--- a/mongodb/vibe/db/mongo/connection.d
+++ b/mongodb/vibe/db/mongo/connection.d
@@ -1120,7 +1120,7 @@ struct ServerDescription
 	Nullable!BsonDate lastWriteDate;
 	Nullable!BsonObjectID opTime;
 	ServerType type = ServerType.unknown;
-	WireVersion minWireVersion, maxWireVersion;
+	int minWireVersion, maxWireVersion;
 	string me;
 	string[] hosts, passives, arbiters;
 	string[string] tags;
@@ -1153,7 +1153,8 @@ enum WireVersion : int
 	v50 = 13,
 	v51 = 14,
 	v52 = 15,
-	v53 = 16
+	v53 = 16,
+	v60 = 17
 }
 
 private string getHostArchitecture()


### PR DESCRIPTION
Since the original PR unfortunately got stuck, this is using and extending the unit tests by @madmax-inc in #2345 and replicates the manual value-to-enum conversion with an added `NoDuplicates` to fix handling of enums with duplicate values.

Fixes #2209. Closes #2345.