### PR TITLE
Make the code forward compatible with std.experimental.allocator

### DIFF
--- a/http/vibe/http/common.d
+++ b/http/vibe/http/common.d
@@ -489,7 +489,7 @@ final class ChunkedOutputStream : OutputStream {
 	}
 
 	/// private
-	this(InterfaceProxy!OutputStream stream, IAllocator alloc, bool dummy)
+	this(Allocator)(InterfaceProxy!OutputStream stream, Allocator alloc, bool dummy)
 	{
 		m_out = stream;
 		m_buffer = AllocAppender!(ubyte[])(alloc);
@@ -611,13 +611,23 @@ final class ChunkedOutputStream : OutputStream {
 }
 
 /// Creates a new `ChunkedInputStream` instance.
-ChunkedOutputStream createChunkedOutputStream(OS)(OS destination_stream, IAllocator allocator = theAllocator()) if (isOutputStream!OS)
+ChunkedOutputStream createChunkedOutputStream(OS)(OS destination_stream) if (isOutputStream!OS)
+{
+	return createChunkedOutputStream(destination_stream, theAllocator());
+}
+/// ditto
+ChunkedOutputStream createChunkedOutputStream(OS, Allocator)(OS destination_stream, Allocator allocator) if (isOutputStream!OS)
 {
 	return new ChunkedOutputStream(interfaceProxy!OutputStream(destination_stream), allocator, true);
 }
 
 /// Creates a new `ChunkedOutputStream` instance.
-FreeListRef!ChunkedOutputStream createChunkedOutputStreamFL(OS)(OS destination_stream, IAllocator allocator = theAllocator()) if (isOutputStream!OS)
+FreeListRef!ChunkedOutputStream createChunkedOutputStreamFL(OS)(OS destination_stream) if (isOutputStream!OS)
+{
+	return createChunkedOutputStreamFL(destination_stream, theAllocator());
+}
+/// ditto
+FreeListRef!ChunkedOutputStream createChunkedOutputStreamFL(OS, Allocator)(OS destination_stream, Allocator allocator) if (isOutputStream!OS)
 {
 	return FreeListRef!ChunkedOutputStream(interfaceProxy!OutputStream(destination_stream), allocator, true);
 }
@@ -1068,4 +1078,27 @@ unittest {
 	} else assert(false);
 	*("foo" in m) = "baz";
 	assert(m["foo"] == "baz");
+}
+
+
+package auto createRequestAllocator()
+{
+	import vibe.container.internal.utilallocator: RegionListAllocator;
+
+	static if (is(RegionListAllocator!(shared(GCAllocator), true) == struct)) {
+		version (VibeManualMemoryManagement)
+			return allocatorObject(RegionListAllocator!(shared(Mallocator), false)(1024, Mallocator.instance));
+		else
+			return allocatorObject(RegionListAllocator!(shared(GCAllocator), true)(1024, GCAllocator.instance));
+	} else {
+		version (VibeManualMemoryManagement)
+			return new RegionListAllocator!(shared(Mallocator), false)(1024, Mallocator.instance);
+		else
+			return new RegionListAllocator!(shared(GCAllocator), true)(1024, GCAllocator.instance);
+	}
+}
+
+package void freeRequestAllocator(Allocator)(ref Allocator alloc)
+{
+	destroy(alloc);
 }

--- a/inet/vibe/inet/message.d
+++ b/inet/vibe/inet/message.d
@@ -32,7 +32,13 @@ import std.string;
 		alloc = Custom allocator to use for allocating strings
 		rfc822_compatible = Flag indicating that duplicate fields should be merged using a comma
 */
-void parseRFC5322Header(InputStream)(InputStream input, ref InetHeaderMap dst, size_t max_line_length = 1000, IAllocator alloc = vibeThreadAllocator(), bool rfc822_compatible = true)
+void parseRFC5322Header(InputStream)(InputStream input, ref InetHeaderMap dst, size_t max_line_length = 1000)
+	if (isInputStream!InputStream)
+{
+	parseRFC5322Header(input, dst, max_line_length, vibeThreadAllocator());
+}
+/// ditto
+void parseRFC5322Header(InputStream, Allocator)(InputStream input, ref InetHeaderMap dst, size_t max_line_length, Allocator alloc, bool rfc822_compatible = true)
 	if (isInputStream!InputStream)
 {
 	string hdr, hdrvalue;

--- a/stream/vibe/stream/memory.d
+++ b/stream/vibe/stream/memory.d
@@ -16,9 +16,9 @@ import std.array;
 import std.exception;
 import std.typecons;
 
-MemoryOutputStream createMemoryOutputStream(IAllocator alloc = vibeThreadAllocator())
+MemoryOutputStream createMemoryOutputStream(Allocator)(Allocator alloc = vibeThreadAllocator())
 @safe nothrow {
-	return new MemoryOutputStream(alloc, true);
+	return new MemoryOutputStream(alloc, MemoryOutputStream.Dummy.init);
 }
 
 /** Creates a new stream with the given data array as its contents.
@@ -39,21 +39,24 @@ MemoryStream createMemoryStream(ubyte[] data, bool writable = true, size_t initi
 */
 final class MemoryOutputStream : OutputStream {
 @safe:
+	private struct Dummy {}
 
 	private {
 		AllocAppender!(ubyte[]) m_destination;
 	}
 
-	deprecated("Use createMemoryOutputStream isntead.")
-	this(IAllocator alloc = vibeThreadAllocator())
-	{
-		this(alloc, true);
-	}
-
 	/// private
-	this(IAllocator alloc, bool dummy)
+	this(IAllocator alloc, Dummy)
 	nothrow {
 		m_destination = AllocAppender!(ubyte[])(alloc);
+	}
+
+	static if (is(RCIAllocator)) {
+		/// private
+		this(RCIAllocator alloc, Dummy)
+		nothrow {
+			m_destination = AllocAppender!(ubyte[])(alloc);
+		}
 	}
 
 	/// An array with all data written to the stream so far.

--- a/stream/vibe/stream/operations.d
+++ b/stream/vibe/stream/operations.d
@@ -33,7 +33,13 @@ import core.time : Duration, seconds;
 		An exception if either the stream end was hit without hitting a newline first, or
 		if more than max_bytes have been read from the stream.
 */
-ubyte[] readLine(InputStream)(InputStream stream, size_t max_bytes = size_t.max, string linesep = "\r\n", IAllocator alloc = vibeThreadAllocator()) /*@ufcs*/
+ubyte[] readLine(InputStream)(InputStream stream, size_t max_bytes = size_t.max, string linesep = "\r\n") /*@ufcs*/
+	if (isInputStream!InputStream)
+{
+	return readLine(stream, max_bytes, linesep, vibeThreadAllocator());
+}
+/// ditto
+ubyte[] readLine(InputStream, Allocator)(InputStream stream, size_t max_bytes, string linesep, Allocator alloc) /*@ufcs*/
 	if (isInputStream!InputStream)
 {
 	auto output = AllocAppender!(ubyte[])(alloc);
@@ -116,7 +122,7 @@ void readLine(R, InputStream)(InputStream stream, ref R dst, size_t max_bytes = 
 		O(n+m) in typical cases, with n being the length of the scanned input
 		string and m the length of the marker.
 */
-ubyte[] readUntil(InputStream)(InputStream stream, in ubyte[] end_marker, size_t max_bytes = size_t.max, IAllocator alloc = vibeThreadAllocator()) /*@ufcs*/
+ubyte[] readUntil(InputStream, Allocator)(InputStream stream, in ubyte[] end_marker, size_t max_bytes = size_t.max, Allocator alloc = vibeThreadAllocator()) /*@ufcs*/
 	if (isInputStream!InputStream)
 {
 	auto output = AllocAppender!(ubyte[])(alloc);

--- a/utils/vibe/utils/string.d
+++ b/utils/vibe/utils/string.d
@@ -161,7 +161,7 @@ sizediff_t matchBracket(const(char)[] str, bool nested = true)
 }
 
 /// Same as std.string.format, just using an allocator.
-string formatAlloc(ARGS...)(scope IAllocator alloc, string fmt, ARGS args)
+string formatAlloc(Allocator, ARGS...)(scope Allocator alloc, string fmt, ARGS args)
 {
 	auto app = AllocAppender!string(alloc);
 	formattedWrite(() @trusted { return &app; } (), fmt, args);


### PR DESCRIPTION
Generalizes the code to take either IAllocator or RCIAllocator.