### PR TITLE
Add a MongoCollection.find(FindOptions) overload.

### DIFF
--- a/examples/bench-mongodb/source/app.d
+++ b/examples/bench-mongodb/source/app.d
@@ -37,8 +37,8 @@ void main()
 	}
 
 	logInfo("Running queries...");
+	static struct Q { int i; }
 	auto dur_query = runTimed({
-		struct Q { int i; }
 		foreach (i; 0 .. nqueries) {
 			auto res = coll.find!Item(Q(5));
 			res.front;

--- a/mongodb/vibe/db/mongo/collection.d
+++ b/mongodb/vibe/db/mongo/collection.d
@@ -519,6 +519,8 @@ struct MongoCollection {
 	  - $(LREF findOne)
 	 */
 	MongoCursor!R find(R = Bson)() { return find!R(Bson.emptyObject, FindOptions.init); }
+	/// ditto
+	MongoCursor!R find(R = Bson)(FindOptions options) { return find!R(Bson.emptyObject, options); }
 
 	///
 	@safe unittest {


### PR DESCRIPTION
Avoids accidental misuse of the API, erroneously treating the FindOptions value as the query.