### PR TITLE
Add viaStatus REST interface attribute.

### DIFF
--- a/tests/rest/source/app.d
+++ b/tests/rest/source/app.d
@@ -395,6 +395,8 @@ interface Example6API
 	// Without a parameter, it will represent the entire body
 	string postConcatBody(@viaBody() FooType obj);
 
+	int testStatus(@viaStatus out int status, @viaStatus out string status_phrase);
+
 	struct FooType {
 		int a;
 		string s;
@@ -439,6 +441,13 @@ override:
 	string postConcatBody(FooType obj)
 	{
 		return postConcat(obj);
+	}
+
+	int testStatus(out int status, out string status_phrase)
+	{
+		status = HTTPStatus.accepted;
+		status_phrase = "Request accepted!";
+		return 42;
 	}
 }
 
@@ -644,6 +653,12 @@ void runTests(string url)
 			assert(tester == "The cake is a lie", tester);
 			assert(www == `Basic realm="Aperture"`.nullable, www.to!string);
 		}
+
+		int status;
+		string status_phrase;
+		assert(api.testStatus(status, status_phrase) == 42);
+		assert(status == HTTPStatus.accepted);
+		assert(status_phrase == "Request accepted!");
 	}
 
 	// Example 6 -- Query

--- a/web/vibe/web/common.d
+++ b/web/vibe/web/common.d
@@ -11,6 +11,7 @@ import vibe.http.common;
 import vibe.http.server : HTTPServerRequest;
 import vibe.data.json;
 import vibe.internal.meta.uda : onlyAsUda, UDATuple;
+import vibe.web.internal.rest.common : ParameterKind;
 
 import std.meta : AliasSeq;
 static import std.utf;
@@ -686,8 +687,6 @@ package struct NoRouteAttribute {}
  * and the parameter (identifier) name of the function.
  */
 public struct WebParamAttribute {
-	import vibe.web.internal.rest.common : ParameterKind;
-
 	/// The type of the WebParamAttribute
 	ParameterKind origin;
 	/// Parameter name (function parameter name).
@@ -722,7 +721,6 @@ public struct WebParamAttribute {
  */
 WebParamAttribute viaBody(string field = null)
 @safe {
-	import vibe.web.internal.rest.common : ParameterKind;
 	if (!__ctfe)
 		assert(false, onlyAsUda!__FUNCTION__);
 	return WebParamAttribute(ParameterKind.body_, null, field);
@@ -735,7 +733,6 @@ in {
 }
 do
 {
-	import vibe.web.internal.rest.common : ParameterKind;
 	if (!__ctfe)
 		assert(false, onlyAsUda!__FUNCTION__);
 	return WebParamAttribute(ParameterKind.body_, identifier, field);
@@ -744,7 +741,6 @@ do
 /// ditto
 WebParamAttribute bodyParam(string identifier)
 @safe {
-	import vibe.web.internal.rest.common : ParameterKind;
 	if (!__ctfe)
 		assert(false, onlyAsUda!__FUNCTION__);
 	return WebParamAttribute(ParameterKind.body_, identifier, "");
@@ -774,7 +770,6 @@ WebParamAttribute bodyParam(string identifier)
  */
 WebParamAttribute viaHeader(string field)
 @safe {
-	import vibe.web.internal.rest.common : ParameterKind;
 	if (!__ctfe)
 		assert(false, onlyAsUda!__FUNCTION__);
 	return WebParamAttribute(ParameterKind.header, null, field);
@@ -783,7 +778,6 @@ WebParamAttribute viaHeader(string field)
 /// Ditto
 WebParamAttribute headerParam(string identifier, string field)
 @safe {
-	import vibe.web.internal.rest.common : ParameterKind;
 	if (!__ctfe)
 		assert(false, onlyAsUda!__FUNCTION__);
 	return WebParamAttribute(ParameterKind.header, identifier, field);
@@ -813,7 +807,6 @@ WebParamAttribute headerParam(string identifier, string field)
  */
 WebParamAttribute viaQuery(string field)
 @safe {
-	import vibe.web.internal.rest.common : ParameterKind;
 	if (!__ctfe)
 		assert(false, onlyAsUda!__FUNCTION__);
 	return WebParamAttribute(ParameterKind.query, null, field);
@@ -822,11 +815,20 @@ WebParamAttribute viaQuery(string field)
 /// Ditto
 WebParamAttribute queryParam(string identifier, string field)
 @safe {
-	import vibe.web.internal.rest.common : ParameterKind;
 	if (!__ctfe)
 		assert(false, onlyAsUda!__FUNCTION__);
 	return WebParamAttribute(ParameterKind.query, identifier, field);
 }
+
+
+/** Declares a parameter to be transmitted via the HTTP status code or phrase.
+
+	This attribute can be applied to one or two `out` parameters of type
+	`HTTPStatus`/`int` or `string`. The values of those parameters correspond
+	to the HTTP status code or phrase, depending on the type.
+*/
+enum viaStatus = WebParamAttribute(ParameterKind.status);
+
 
 /**
 	Determines the naming convention of an identifier.

--- a/web/vibe/web/internal/rest/common.d
+++ b/web/vibe/web/internal/rest/common.d
@@ -199,6 +199,7 @@ import std.traits : hasUDA;
 					case ParameterKind.internal: route.internalParameters ~= pi; break;
 					case ParameterKind.attributed: route.attributedParameters ~= pi; break;
 					case ParameterKind.auth: route.authParameters ~= pi; break;
+					case ParameterKind.status: route.statusParameters ~= pi; break;
 				}
 			}
 
@@ -437,6 +438,7 @@ struct Route {
 	Parameter[] attributedParameters;
 	Parameter[] internalParameters;
 	Parameter[] authParameters;
+	Parameter[] statusParameters;
 }
 
 struct PathPart {
@@ -474,7 +476,8 @@ enum ParameterKind {
 	header,      // req.header[]
 	attributed,  // @before
 	internal,    // req.params[]
-	auth         // @authrorized!T
+	auth,        // @authrorized!T
+	status       // res.statusCode/res.statusPhrase
 }
 
 struct SubInterface {


### PR DESCRIPTION
Allows customizing the HTTP response status in a cleaner way than (ab)using an `@after` annotation.

See https://forum.rejectedsoftware.com/groups/rejectedsoftware.vibed/thread/279951/