### PR TITLE
Fix compilation error for Confirm!T parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,11 +13,13 @@ v0.10.2 - 2025-
 ### Bug fixes ###
 
 - Fixed parsing plural-only translations in PO files and improves error messages - [pull #2805][issue2805]
+- Fixed a compilation error when using `Confirm!T` parameters in a web interface - [pull #2816][issue2816]
 
 [issue2804]: https://github.com/vibe-d/vibe.d/issues/2804
 [issue2805]: https://github.com/vibe-d/vibe.d/issues/2805
 [issue2806]: https://github.com/vibe-d/vibe.d/issues/2806
 [issue2815]: https://github.com/vibe-d/vibe.d/issues/2815
+[issue2816]: https://github.com/vibe-d/vibe.d/issues/2816
 
 
 v0.10.1 - 2024-09-07

--- a/web/vibe/web/web.d
+++ b/web/vibe/web/web.d
@@ -998,9 +998,9 @@ private void handleRequest(string M, alias overload, C, ERROR...)(HTTPServerRequ
 		else alias ParamBaseType = PT;
 
 		static if (isInstanceOf!(Confirm, ParamBaseType)) {
-			enum pidx = param_names.countUntil(PT.confirmedParameter);
-			static assert(pidx >= 0, "Unknown confirmation parameter reference \""~PT.confirmedParameter~"\".");
-			static assert(pidx != i, "Confirmation parameter \""~PT.confirmedParameter~"\" may not reference itself.");
+			enum pidx = param_names.countUntil(ParamBaseType.confirmedParameter);
+			static assert(pidx >= 0, "Unknown confirmation parameter reference \""~ParamBaseType.confirmedParameter~"\".");
+			static assert(pidx != i, "Confirmation parameter \""~ParamBaseType.confirmedParameter~"\" may not reference itself.");
 
 			bool matched;
 			static if (isNullable!PT && isNullable!(PARAMS[pidx])) {


### PR DESCRIPTION
Since `Nullable!T` has removed the `alias this`, static members cannot be accessed via the `Nullable` anymore.